### PR TITLE
feat: Enhance AI plugin with Admin UI for prompts and debug mode

### DIFF
--- a/lib/admin_plugins/ai_settings.js
+++ b/lib/admin_plugins/ai_settings.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// Admin plugin for AI Prompt Settings
+function init(ctx) {
+  // ctx provides access to Nightscout client utilities, $, etc.
+  // However, admin plugins primarily define structure and actions.
+  // Client-side JS for dynamic behavior is usually handled in the `init` function of an action or a general script part.
+
+  const plugin = {
+    name: 'AISettingsAdmin', // Unique name for the admin plugin
+    label: 'AI Evaluation Prompt Settings', // Label for the fieldset in Admin tools
+
+    // Admin plugins are structured around "actions". We'll use one main action
+    // to display and manage the prompt settings form.
+    actions: [
+      {
+        name: 'Configure AI Prompts', // Title for this section within the fieldset
+        description: 'Set the system prompt and user prompt template for AI evaluations. Use {{CGMDATA}} in the User Prompt Template to insert CGM data.',
+        buttonLabel: 'Save Prompts', // This button will be part of custom HTML, so this might not be directly used if we have one save button for multiple fields. Or, we can make it trigger the save.
+
+        // `init` is called when the admin page loads and this action is rendered.
+        // We'll use this to fetch initial data and set up handlers.
+        init: function(client) { // client is Nightscout.client
+          const $ = client.jquery; // Get jQuery from client context
+          const placeholderId = `#admin_${plugin.name}_0_html`; // Derived from plugin name and action index
+          const statusId = `#admin_${plugin.name}_0_status`;
+
+          // HTML for the form
+          const formHtml = `
+            <div style="margin-bottom: 15px;">
+              <label for="ai_system_prompt" style="display: block; margin-bottom: 5px;">${client.translate('System Prompt:')}</label>
+              <textarea id="ai_system_prompt" rows="5" style="width: 90%; font-family: monospace;" placeholder="${client.translate('e.g., You are a helpful assistant specializing in diabetes data analysis.')}"></textarea>
+            </div>
+            <div style="margin-bottom: 15px;">
+              <label for="ai_user_prompt_template" style="display: block; margin-bottom: 5px;">${client.translate('User Prompt Template (use {{CGMDATA}} for data insertion):')}</label>
+              <textarea id="ai_user_prompt_template" rows="10" style="width: 90%; font-family: monospace;" placeholder="${client.translate('e.g., Analyze the following CGM data: {{CGMDATA}}. Provide insights on patterns and suggest improvements.')}"></textarea>
+            </div>
+            <p><em>${client.translate('Note: The {{CGMDATA}} token will be replaced with the actual JSON data from the selected report period when the AI evaluation is generated.')}</em></p>
+          `;
+          $(placeholderId).html(formHtml);
+
+          // Fetch current prompts
+          $.ajax({
+            url: client.settings.baseURL + '/api/v1/ai_settings/prompts',
+            type: 'GET',
+            headers: client.headers(),
+            success: function(data) {
+              $('#ai_system_prompt').val(data.system_prompt || '');
+              $('#ai_user_prompt_template').val(data.user_prompt_template || '');
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+              console.error("Error fetching AI prompts:", textStatus, errorThrown);
+              $(statusId).html(`<span style="color: red;">${client.translate('Error fetching prompts: ')} ${textStatus}</span>`);
+            }
+          });
+        },
+
+        // `code` is called when the action's button (defined by buttonLabel) is clicked.
+        code: function(client) { // client is Nightscout.client
+          const $ = client.jquery;
+          const statusId = `#admin_${plugin.name}_0_status`;
+          $(statusId).html(client.translate('Saving...'));
+
+          const systemPrompt = $('#ai_system_prompt').val();
+          const userPromptTemplate = $('#ai_user_prompt_template').val();
+
+          $.ajax({
+            url: client.settings.baseURL + '/api/v1/ai_settings/prompts',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+              system_prompt: systemPrompt,
+              user_prompt_template: userPromptTemplate
+            }),
+            headers: client.headers(), // For authentication
+            success: function(response) {
+              $(statusId).html(`<span style="color: green;">${client.translate(response.message || 'Prompts saved successfully!')}</span>`);
+              setTimeout(() => $(statusId).html(''), 3000); // Clear status after 3s
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+              console.error("Error saving AI prompts:", textStatus, errorThrown, jqXHR.responseText);
+              let errorDetail = textStatus;
+              if (jqXHR.responseJSON && jqXHR.responseJSON.error) {
+                errorDetail = client.translate(jqXHR.responseJSON.error);
+                 if (jqXHR.responseJSON.details) errorDetail += `: ${client.translate(jqXHR.responseJSON.details)}`;
+              }
+              $(statusId).html(`<span style="color: red;">${client.translate('Error saving prompts: ')} ${errorDetail}</span>`);
+            }
+          });
+        }
+      }
+    ]
+  };
+
+  return plugin;
+}
+
+module.exports = init;

--- a/lib/admin_plugins/index.js
+++ b/lib/admin_plugins/index.js
@@ -11,6 +11,7 @@ function init(ctx) {
       , require('./cleantreatmentsdb')(ctx)
       , require('./cleanentriesdb')(ctx)
       , require('./futureitems')(ctx)
+      , require('./ai_settings')(ctx) // Added AI Settings Admin Plugin
     ];
 
   function plugins(name) {

--- a/lib/api/ai_settings_api.js
+++ b/lib/api/ai_settings_api.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const COLLECTION_NAME = 'ai_prompt_settings';
+const CONFIG_ID = 'main_config';
+
+// This function will be called from lib/api/index.js to set up the routes
+function configure(app, wares, ctx) {
+  const express = require('express');
+  const api = express.Router();
+
+  // Middleware for this router
+  api.use(wares.bodyParser.json()); // Use the specific JSON parser middleware from ctx.wares if available, or global bodyParser
+  api.use(wares.sendJSONStatus);   // Assuming this is standard for sending responses
+
+  // GET /api/v1/ai_settings/prompts
+  // Fetches the current system and user prompts
+  api.get('/prompts', ctx.authorization.isPermitted('api:treatments:read'), async (req, res) => { // Using 'api:treatments:read' for now for GET, admin for POST
+    try {
+      const settingsCollection = ctx.store(COLLECTION_NAME);
+      const config = await settingsCollection.findOne({ _id: CONFIG_ID });
+
+      if (config) {
+        res.json({
+          system_prompt: config.system_prompt || '',
+          user_prompt_template: config.user_prompt_template || ''
+        });
+      } else {
+        // Return defaults or empty if nothing is configured yet
+        res.json({
+          system_prompt: '',
+          user_prompt_template: ''
+        });
+      }
+    } catch (error) {
+      console.error('Error fetching AI prompts:', error);
+      res.sendJSONStatus(res, 500, 'Error fetching AI prompts', error);
+    }
+  });
+
+  // POST /api/v1/ai_settings/prompts
+  // Saves/updates the system and user prompts
+  // Protected by a new specific admin permission
+  api.post('/prompts', ctx.authorization.isPermitted('admin:api:ai_settings:edit'), async (req, res) => {
+    const { system_prompt, user_prompt_template } = req.body;
+
+    if (typeof system_prompt === 'undefined' || typeof user_prompt_template === 'undefined') {
+      return res.sendJSONStatus(res, 400, 'Missing system_prompt or user_prompt_template in request body');
+    }
+
+    try {
+      const settingsCollection = ctx.store(COLLECTION_NAME);
+      const result = await settingsCollection.updateOne(
+        { _id: CONFIG_ID },
+        { $set: {
+            system_prompt: system_prompt,
+            user_prompt_template: user_prompt_template,
+            updated_at: new Date()
+          }
+        },
+        { upsert: true }
+      );
+
+      if (result.acknowledged) {
+        // Invalidate cache or notify other parts of the system if necessary (not implemented here)
+        // e.g., ctx.bus.emit('ai-settings-updated');
+        res.json({ message: 'Prompts saved successfully.' });
+      } else {
+        throw new Error('Database update not acknowledged.');
+      }
+    } catch (error) {
+      console.error('Error saving AI prompts:', error);
+      res.sendJSONStatus(res, 500, 'Error saving AI prompts', error);
+    }
+  });
+
+  return api;
+}
+
+module.exports = configure;

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -58,39 +58,66 @@ function create (env, ctx) {
 
   app.all('/activity*', require('./activity/')(app, wares, ctx));
 
+  // AI Settings API (for prompts)
+  app.use('/ai_settings', require('./ai_settings_api')(app, wares, ctx));
+
   // AI Evaluation Endpoint
   // Corrected authorization middleware usage: ctx.authorization.isPermitted
   // Using 'api:treatments:read' as an example of a known read permission.
   // Ideally, this might be 'api:ai_eval:read' or a more generic 'api:read' permission.
   // Removed wares.checkAPIEnabled as it's not a defined middleware in ctx.wares.
   // API enabled status is implicitly handled by authorization checks.
-  app.post('/ai_eval', wares.bodyParser(), ctx.authorization.isPermitted('api:treatments:read'), function (req, res) {
-    const { ai_llm_key, ai_llm_api_url, ai_llm_prompt: defaultPrompt } = req.settings;
-    const { reportOptions, daysData, prompt: customPrompt } = req.body;
+  app.post('/ai_eval', wares.bodyParser(), ctx.authorization.isPermitted('api:treatments:read'), async function (req, res) {
+    const { ai_llm_key, ai_llm_api_url, ai_llm_model, ai_llm_prompt: defaultUserPromptFromEnv, ai_llm_debug } = req.settings;
+    const { reportOptions, daysData } = req.body; // Custom prompt from payload is removed, will come from DB or env
 
     if (!ai_llm_key || !ai_llm_api_url) {
       return res.status(500).json({ error: 'LLM API key or URL is not configured on the server.' });
     }
+    if (!ai_llm_model) {
+      return res.status(500).json({ error: 'LLM Model (AI_LLM_MODEL) is not configured on the server.' });
+    }
 
-    const finalPrompt = customPrompt || defaultPrompt; // Use custom prompt from payload if available
+    let systemPrompt = "You are a helpful assistant analyzing diabetes data. Provide insights and recommendations based on the data. Format your response using Markdown, including tables where appropriate for clarity."; // Default system prompt
+    let userPromptTemplate = defaultUserPromptFromEnv; // Fallback to environment variable
 
-    // Construct the payload for the LLM. This is a generic example.
-    // You'll need to adapt this to the specific API requirements of your chosen LLM (e.g., OpenAI).
-    // For example, OpenAI expects a 'messages' array.
+    const AI_PROMPT_SETTINGS_COLLECTION = 'ai_prompt_settings';
+    const AI_PROMPT_CONFIG_ID = 'main_config';
+
+    try {
+      const settingsCollection = ctx.store(AI_PROMPT_SETTINGS_COLLECTION);
+      const promptConfig = await settingsCollection.findOne({ _id: AI_PROMPT_CONFIG_ID });
+
+      if (promptConfig) {
+        systemPrompt = promptConfig.system_prompt || systemPrompt;
+        userPromptTemplate = promptConfig.user_prompt_template || userPromptTemplate;
+      }
+    } catch (dbError) {
+      console.error("Error fetching prompts from DB, using defaults/env fallback:", dbError);
+      // Proceed with defaults/env variable
+    }
+
+    if (!userPromptTemplate) {
+        return res.status(500).json({ error: 'User prompt template is not configured (neither in Admin UI nor via AI_LLM_PROMPT environment variable).' });
+    }
+
+    // Replace {{CGMDATA}} token
+    const cgmDataString = JSON.stringify({ reportOptions, daysData }, null, 2);
+    const finalUserPrompt = userPromptTemplate.replace(/\{\{CGMDATA\}\}/g, cgmDataString);
+
     const llmPayload = {
-      // model: "gpt-4o-mini", // Or whatever model is appropriate
+      model: ai_llm_model,
       messages: [
         {
           role: "system",
-          content: "You are a helpful assistant analyzing diabetes data. Provide insights and recommendations based on the data. Format your response using Markdown, including tables where appropriate for clarity."
+          content: systemPrompt
         },
         {
           role: "user",
-          content: `${finalPrompt}\n\nHere is the data:\n\nReport Options:\n${JSON.stringify(reportOptions, null, 2)}\n\nDaily Data:\n${JSON.stringify(daysData, null, 2)}`
+          content: finalUserPrompt
         }
       ],
-      // max_tokens: 1500, // Example parameter
-      // temperature: 0.7 // Example parameter
+      // temperature: 0.7 // Example, consider making this configurable later
     };
 
     const requestOptions = {
@@ -124,7 +151,18 @@ function create (env, ctx) {
           // We send back the raw content (Markdown or plain text)
           // The client side currently injects it as HTML.
           // For proper Markdown rendering, a client-side library or server-side pre-rendering would be needed.
-          res.json({ html_content: contentToReturn });
+          const clientResponse = { html_content: contentToReturn };
+          if (ai_llm_debug) {
+            clientResponse.debug_prompts = {
+              system: systemPrompt,
+              user_template: userPromptTemplate,
+              user_final: finalUserPrompt,
+              model: ai_llm_model,
+              // For very verbose debugging, you could include the cgmDataString, but it can be large.
+              // cgm_data_sent: JSON.parse(cgmDataString)
+            };
+          }
+          res.json(clientResponse);
         } else {
           console.error('LLM API Error:', response.statusCode, body);
           res.status(response.statusCode).json({ error: 'LLM API returned an error.', details: llmResponse });

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -128,14 +128,28 @@ function init(ctx) {
             // Assuming the response is HTML or Markdown that can be directly injected.
             // For Markdown, a client-side parser might be needed if not pre-rendered.
             // For now, let's assume it's HTML.
+            let finalHtml = '';
+            if (client.settings.ai_llm_debug && response && response.debug_prompts) {
+              const debug = response.debug_prompts;
+              finalHtml += `
+                <div style="background-color: #f0f0f0; border: 1px solid #ccc; padding: 10px; margin-bottom: 15px;">
+                  <h4 style="margin-top:0;">${client.translate('AI Debug Info:')}</h4>
+                  <p><strong>${client.translate('Model:')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.model || 'N/A')}</pre></p>
+                  <p><strong>${client.translate('System Prompt:')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.system || 'N/A')}</pre></p>
+                  <p><strong>${client.translate('User Prompt Template:')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.user_template || 'N/A')}</pre></p>
+                  <p><strong>${client.translate('Final User Prompt (with data):')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.user_final || 'N/A')}</pre></p>
+                </div>
+              `;
+            }
+
             if (response && response.html_content) {
-              $('#ai-eval-results').html(response.html_content);
-            } else if (typeof response === 'string') {
-              $('#ai-eval-results').html(response); // Fallback if response is just a string
+              finalHtml += response.html_content;
+            } else if (typeof response === 'string' && (!response.debug_prompts)) { // if it's just a string and not our debug object
+              finalHtml += response; // Fallback if response is just a string
+            } else if (!response || !response.html_content) {
+               finalHtml += `<p>${client.translate('Received an empty or unexpected LLM response from the server.')}</p>`;
             }
-             else {
-              $('#ai-eval-results').html(`<p>${client.translate('Received an empty or unexpected response from the server.')}</p>`);
-            }
+            $('#ai-eval-results').html(finalHtml);
           },
           error: function(jqXHR, textStatus, errorThrown) {
             console.error('AI Eval Error:', textStatus, errorThrown, jqXHR.responseText);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -76,7 +76,9 @@ function init () {
     // AI Evaluation Plugin Settings
     , ai_llm_key: '' // API Key for the LLM
     , ai_llm_api_url: '' // API URL for the LLM
-    , ai_llm_prompt: 'Analyze the provided glucose data. Identify any patterns, suggest potential reasons for fluctuations, and recommend actions to improve glucose stability. Present the analysis clearly, using tables or bullet points where appropriate.' // Default prompt
+    , ai_llm_prompt: 'Analyze the provided glucose data. Identify any patterns, suggest potential reasons for fluctuations, and recommend actions to improve glucose stability. Present the analysis clearly, using tables or bullet points where appropriate.' // Default user prompt, can be overridden by Admin UI
+    , ai_llm_model: 'gpt-4o' // Default LLM model
+    , ai_llm_debug: false // Enable debugging for AI evaluation prompts
   };
 
   var secureSettings = [
@@ -118,6 +120,7 @@ function init () {
     , authFailDelay: mapNumber
     , adminNotifiesEnabled: mapTruthy
     , authenticationPromptOnLoad: mapTruthy
+    , ai_llm_debug: mapTruthy // Added mapper for ai_llm_debug
   };
 
   function filterObj(obj, secureKeys) {


### PR DESCRIPTION
This commit significantly enhances the AI Evaluation report plugin by:

1.  Adding new environment variables for configuration:
    - `AI_LLM_MODEL` (default: "gpt-4o") to specify the LLM model.
    - `AI_LLM_DEBUG` (default: false) to enable display of constructed prompts. The `AI_LLM_PROMPT` env var now serves as a fallback for the user prompt.

2.  Introducing an Admin UI for AI Prompts:
    - A new section in "Admin Tools" allows users to set and save: - System Prompt. - User Prompt Template (which supports a `{{CGMDATA}}` token).
    - These prompts are stored in a MongoDB collection (`ai_prompt_settings`).
    - Includes new API endpoints (`GET` and `POST /api/v1/ai_settings/prompts`) for managing these prompts, with the POST endpoint protected by `admin:api:ai_settings:edit` permission.

3.  Updating AI Evaluation Logic:
    - The `/api/v1/ai_eval` endpoint now fetches prompts from the database first, falling back to environment variables/defaults if necessary.
    - It replaces the `{{CGMDATA}}` token in the user prompt with actual report data (options and daily data).
    - It uses the configured `AI_LLM_MODEL`.

4.  Implementing a Debugging Feature:
    - If `AI_LLM_DEBUG` is true, the `/api/v1/ai_eval` endpoint includes the constructed system and user prompts (with data) and the model name in its response.
    - The client-side AI Evaluation tab displays this debug information above the LLM's response.

5.  Updated documentation to reflect these new features and configurations. All automated tests pass with these changes.