### PR TITLE
fix: Temporarily use raw string for admin UI label to test translate …

### DIFF
--- a/lib/admin_plugins/ai_settings.js
+++ b/lib/admin_plugins/ai_settings.js
@@ -35,7 +35,7 @@ function init(ctx) {
 
           $formContainer.append(
             $('<div>').css('margin-bottom', '15px').append(
-              $('<label>').attr('for', systemPromptId).css({display: 'block', marginBottom: '5px'}).text(client.translate('System Prompt:')),
+              $('<label>').attr('for', systemPromptId).css({display: 'block', marginBottom: '5px'}).text('System Prompt: (Raw Test)'), // Temporarily use raw string
               $('<textarea>').attr('id', systemPromptId).attr('rows', 5).css({width: '90%', fontFamily: 'monospace'}).attr('placeholder', client.translate('e.g., You are a helpful assistant specializing in diabetes data analysis.'))
             )
           );


### PR DESCRIPTION
…issue

Replaces one instance of client.translate() with a raw string in lib/admin_plugins/ai_settings.js. This is a diagnostic step to confirm if client.translate is the source of the TypeError that prevents the AI prompt settings textareas from rendering.