### PR TITLE
debug: Add console logs to ai_settings admin plugin for diagnostics

### DIFF
--- a/lib/admin_plugins/ai_settings.js
+++ b/lib/admin_plugins/ai_settings.js
@@ -29,6 +29,24 @@ function init(ctx) {
           const systemPromptId = `ai_system_prompt_${plugin.name}`;
           const userPromptTemplateId = `ai_user_prompt_template_${plugin.name}`;
 
+          // --- BEGIN DIAGNOSTIC CONSOLE LOGS ---
+          console.log('[AISettingsAdmin] init called. Client object:', client);
+          if (client) {
+            console.log('[AISettingsAdmin] typeof client.jquery:', typeof client.jquery);
+            if (typeof client.jquery === 'function') {
+              console.log('[AISettingsAdmin] client.jquery === window.jQuery?', client.jquery === window.jQuery);
+              console.log('[AISettingsAdmin] Is $ (client.jquery) a function?', typeof $ === 'function');
+              if (typeof $ === 'function') {
+                console.log('[AISettingsAdmin] Attempting to select placeholder with $:', $(placeholderId).length ? 'found' : 'not found');
+              }
+            }
+            console.log('[AISettingsAdmin] typeof client.translate:', typeof client.translate);
+          } else {
+            console.error('[AISettingsAdmin] client object is undefined or null in init!');
+          }
+          console.log('[AISettingsAdmin] Placeholder ID being used:', placeholderId);
+          // --- END DIAGNOSTIC CONSOLE LOGS ---
+
           // HTML for the form, using unique IDs
           // Using jQuery to build the form elements to ensure proper context if $ is later reassigned.
           const $formContainer = $('<div>'); // Create a container for our form elements


### PR DESCRIPTION
Adds console.log statements to the init function in lib/admin_plugins/ai_settings.js to help diagnose the TypeError "n is not a function" by inspecting the state of client.jquery and client.translate when the plugin initializes.