### PR TITLE
fix: Resolve rendering interference and improve error display

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -79,20 +79,23 @@ A new section in Admin Tools allows you to monitor LLM usage:
 1.  **Navigate to Reports:** Go to the "Reports" section of your Nightscout site.
 2.  **Load Report Data:** Select any standard report type (e.g., "Day to day," "Daily Stats"), choose your desired date range and other relevant filters, and click the main "Show" button for the reports. This action loads the data that will be available for the AI evaluation.
 3.  **Open AI Evaluation Tab:** In the list of report tabs, click on "AI Evaluation".
-4.  **Generate Analysis:** Click the "Show AI Evaluation" button within this tab.
-    *   The system will use your configured prompts (from Admin UI or fallbacks) and the loaded report data.
-    *   The request is sent to the LLM. This may take a few moments.
-    *   The LLM's response will be displayed in the tab. If `AI_LLM_DEBUG` is enabled, debug information will appear above the response.
+    *   Upon opening the tab, the plugin will automatically check for all required configurations (API URL, Model, System Prompt, User Prompt Template).
+    *   If any settings are missing, a detailed error message will be displayed, guiding you on where to configure each item.
+    *   If all settings are correctly configured, a confirmation message will appear.
+4.  **Automatic Analysis:**
+    *   Once the main report data (from step 2) is loaded and all AI settings are confirmed to be correct, the AI evaluation will **automatically begin**. There is no separate "Show AI Evaluation" button to click in this tab.
+    *   The system will display "Loading AI evaluation..." while it processes the data and communicates with the LLM.
+    *   The LLM's response will then be displayed in the main content area of the tab.
 
 ### 3. Understanding the Output
 
-*   The output is the direct response from the LLM, based on your prompts and data.
-*   It may include text, lists, and potentially tables (if the LLM formats it in Markdown and your browser renders it).
-*   If `AI_LLM_DEBUG` is `true`, a section above the response will show:
-    *   Model used.
-    *   System Prompt sent.
-    *   User Prompt Template (before data injection).
-    *   Final User Prompt (after `{{CGMDATA}}` was replaced).
+*   **AI Evaluation:** The main content area will show the direct response from the LLM, based on your prompts and data. This may include text, lists, and potentially tables.
+*   **Token Usage:** Information about the number of tokens used for the current evaluation will be displayed (e.g., "Tokens used for this evaluation: XXXX"). This can help you monitor usage.
+*   **Debug Information (If Enabled):** If `AI_LLM_DEBUG` is set to `true` (see Configuration section), a dedicated "AI Debug Info" section will appear above the AI's response. This section will display:
+    *   **Model:** The LLM model used for the request.
+    *   **System Prompt:** The exact system prompt sent to the LLM.
+    *   **Final User Prompt (with data injected):** The complete user prompt after the `{{CGMDATA}}` token was replaced with your actual report data. This is very useful for understanding exactly what information the LLM received.
+    *   *(The User Prompt Template as stored in settings is not directly shown here, but the Final User Prompt reflects its use).*
 
 ### 4. Troubleshooting
 
@@ -125,10 +128,20 @@ A new section in Admin Tools allows you to monitor LLM usage:
     *   Added `mapTruthy` for `ai_llm_debug`.
 *   **`lib/report_plugins/ai_eval.js`:**
     *   The main file for the "AI Evaluation" report tab UI and client-side logic.
-    *   Stores `datastorage`, `sorteddaystoshow`, and `options` when the main report is generated.
-    *   Handles the "Show AI Evaluation" button click.
-    *   Makes an AJAX POST request to `/api/v1/ai_eval`.
-    *   Displays the LLM response and, if `AI_LLM_DEBUG` is true, the debug information received from the server.
+    *   **UI Changes:**
+        *   Removed the dedicated "Show AI Evaluation" button.
+        *   Added new HTML elements: `#ai-eval-status-area` for configuration status and errors, `#ai-eval-debug-info` for debug output, and `#ai-eval-results` for LLM responses.
+    *   **Automatic Trigger:**
+        *   Performs a comprehensive settings check (client settings, server prompts via API) when the tab is activated.
+        *   Displays detailed error messages if settings are missing, or a success message if all are configured.
+        *   Automatically triggers the AI evaluation via the `report()` function when main report data is available and all settings are valid.
+    *   **Data Payload:**
+        *   Constructs a detailed JSON payload for the `{{CGMDATA}}` token. This includes `reportSettings` (targets, units, dates, report name), `entries` (SGV, MBG), `treatments` (insulin, carbs, notes, timestamps), `profile` data (timezone, basal, CR, ISF, fetched via `client.profile()`), and `deviceStatus` data.
+    *   **AJAX Call & Display:**
+        *   Makes an AJAX POST request to `/api/v1/ai_eval` with the constructed data payload.
+        *   Displays the LLM's HTML response.
+        *   If `AI_LLM_DEBUG` is true, displays formatted debug information (model, system prompt, final user prompt with data) in `#ai-eval-debug-info`.
+        *   Displays the `tokens_used` for the current request.
 *   **`lib/admin_plugins/ai_settings.js`:**
     *   New admin plugin for the UI in Admin Tools to manage AI prompts.
     *   Renders textareas for system and user prompts.
@@ -207,22 +220,43 @@ A new section in Admin Tools allows you to monitor LLM usage:
 
 ### 4. Data Flow for AI Evaluation
 
-1.  User loads data in a standard Nightscout report. This populates `storedData` in `ai_eval.js`.
-2.  User clicks "Show AI Evaluation" in the AI tab.
-3.  Client-side script in `ai_eval.js` sends `reportOptions` and `daysData` to `POST /api/v1/ai_eval`.
-4.  Server-side `/ai_eval` endpoint:
+1.  **User loads data in a standard Nightscout report.** This action (e.g., clicking "Show" on the "Day to day" report) makes `datastorage`, `sorteddaystoshow`, and `options` available to plugins.
+2.  **User navigates to the "AI Evaluation" tab.**
+    a.  The `script` in `lib/report_plugins/ai_eval.js` immediately performs a comprehensive settings check:
+        i.  Verifies client-side settings (`ai_llm_api_url`, `ai_llm_model`).
+        ii. Fetches server-side prompts (`system_prompt`, `user_prompt_template`) via `GET /api/v1/ai_settings/prompts`.
+    b.  The UI in `#ai-eval-status-area` is updated with either a success message or a list of missing configurations.
+3.  **Main report data triggers AI evaluation (if settings are valid):**
+    a.  The `report(datastorage, sorteddaystoshow, options)` function in `ai_eval.js` is called by Nightscout's report client when data is ready.
+    b.  This function stores the data and then re-runs the settings check logic (or uses its current state).
+    c.  If settings are valid and data is present:
+        i.  A `cgmDataPayload` object is constructed. This object contains:
+            *   `reportSettings`: Target glucose range, units, date range, report name.
+            *   `entries`: Array of SGV, MBG data points with timestamps.
+            *   `treatments`: Array of treatment data (insulin, carbs, notes, timestamps, etc.).
+            *   `profile`: Current active profile data (timezone, basal rates, ISF, carb ratios) obtained via `client.profile()`.
+            *   `deviceStatus`: Array of device status entries (if available in the loaded report data).
+        ii. `client.triggerAIEvaluation(cgmDataPayload)` is called.
+4.  **Client-side AJAX request:**
+    a.  `client.triggerAIEvaluation` sets the UI to a "Loading AI evaluation..." state.
+    b.  It sends the `cgmDataPayload` as a JSON body in a `POST` request to `/api/v1/ai_eval`.
+5.  **Server-side `/api/v1/ai_eval` endpoint:**
     a.  Retrieves `AI_LLM_KEY`, `AI_LLM_API_URL`, `AI_LLM_MODEL`, `AI_LLM_DEBUG` from `req.settings`.
-    b.  Fetches `system_prompt` and `user_prompt_template` from the `ai_prompt_settings` MongoDB collection.
-    c.  If DB prompts are not found, uses a default system prompt and `req.settings.ai_llm_prompt` for the user template.
-    d.  Replaces `{{CGMDATA}}` in the user prompt template with a JSON string of `reportOptions` and `daysData`.
-    e.  Constructs the LLM payload (model, system message, final user message).
-    f.  Makes a POST request to `AI_LLM_API_URL` with the payload and `AI_LLM_KEY`.
-    g.  Receives the LLM's response.
-    h.  If the LLM call is successful and token information (e.g., `response.usage.total_tokens`) is available, makes an internal POST request to `/api/v1/ai_usage/record` with the token count.
-    i.  Constructs a JSON response for the client, including `html_content` (LLM's answer) and optionally `debug_prompts`.
-5.  Client-side script in `ai_eval.js` receives the response.
-    a.  If `AI_LLM_DEBUG` is true and `debug_prompts` are present, displays them.
-    b.  Displays `html_content`.
+    b.  Fetches `system_prompt` and `user_prompt_template` from the `ai_prompt_settings` MongoDB collection (or uses fallbacks if not found in DB but present in environment variables).
+    c.  The received `cgmDataPayload` (from the request body) is stringified and injected into the `{{CGMDATA}}` token of the `user_prompt_template`.
+    d.  Constructs the final LLM payload (model, system message, final user message with injected data).
+    e.  Makes a POST request to the configured `AI_LLM_API_URL` with the LLM payload and `AI_LLM_KEY`.
+    f.  Receives the LLM's response.
+    g.  If the LLM call is successful and token information (e.g., `response.data.usage.total_tokens` for OpenAI) is available, it makes an internal POST request to `/api/v1/ai_usage/record` with the `total_tokens`.
+    h.  Constructs a JSON response for the client. This response includes:
+        *   `html_content`: The LLM's answer.
+        *   `tokens_used`: The number of tokens consumed for this specific request.
+        *   `debug_info` (if `AI_LLM_DEBUG` is true): An object containing `model`, `system_prompt`, and `final_user_prompt`.
+6.  **Client-side script in `ai_eval.js` receives the response:**
+    a.  Displays the `html_content` in `#ai-eval-results`.
+    b.  Displays the `tokens_used` information (e.g., in `#ai-eval-status-area` or near results).
+    c.  If `AI_LLM_DEBUG` is true and `debug_info` is present, it's formatted and displayed in `#ai-eval-debug-info`.
+    d.  Handles and displays any errors received from the server.
 
 ### 5. Permissions
 

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -18,25 +18,135 @@ function init(ctx) {
 
     // This function is called by reportclient.js when main report data is loaded
     report: function(datastorage, sorteddaystoshow, options) {
-      // Store the data for later use by the button
+      console.log('AI Eval plugin: report function called with new data.');
       storedData.datastorage = datastorage;
       storedData.sorteddaystoshow = sorteddaystoshow;
       storedData.options = options;
-      // console.log('AI Eval plugin: Data stored by report function.', storedData);
 
-      // Clear previous results if any when new main report is generated
+      // Clear previous results and debug info when new main report data is loaded
+      // Only do this if the AI eval tab is the currently active one,
+      // or defer this to when the tab becomes active.
+      // For now, let's assume this is fine, as results are specific to data.
       $('#ai-eval-results').html('');
+      $('#ai-eval-debug-info').html('');
+      // The status area message (config valid/invalid) should persist.
+
+      // Decision to trigger AI evaluation now relies on currentConfigurationIsValid flag
+      // which is set when the tab's script is loaded/activated.
+      if (currentConfigurationIsValid) {
+        if (storedData.datastorage && storedData.sorteddaystoshow && storedData.options) {
+          $('#ai-eval-results').html(client.translate('Preparing data for AI evaluation...'));
+
+          let cgmDataPayload = {
+            reportSettings: {
+              targetLow: storedData.options.targetLow,
+              targetHigh: storedData.options.targetHigh,
+              units: storedData.options.units,
+              dateFrom: storedData.sorteddaystoshow.length > 0 ? storedData.sorteddaystoshow[0] : null,
+              dateTo: storedData.sorteddaystoshow.length > 0 ? storedData.sorteddaystoshow[storedData.sorteddaystoshow.length - 1] : null,
+              reportName: storedData.options.reportName
+            },
+            entries: [],
+            treatments: [],
+            deviceStatus: [],
+            profile: {}
+          };
+
+          try {
+            // Attempt to get profile data
+            if (client && typeof client.profile === 'function') {
+              const fullProfile = client.profile();
+              if (fullProfile && fullProfile.store && fullProfile.store[fullProfile.defaultProfile]) {
+                const activeProfileStore = fullProfile.store[fullProfile.defaultProfile];
+                cgmDataPayload.profile = {
+                  timezone: activeProfileStore.timezone,
+                  basal: activeProfileStore.basal,
+                  carbratio: activeProfileStore.carbratio,
+                  sens: activeProfileStore.sens
+                };
+              } else if (fullProfile && fullProfile.defaultProfile && fullProfile[fullProfile.defaultProfile]) {
+                const activeProfileData = fullProfile[fullProfile.defaultProfile];
+                cgmDataPayload.profile = {
+                  timezone: activeProfileData.timezone,
+                  basal: activeProfileData.basal,
+                  carbratio: activeProfileData.carbratio,
+                  sens: activeProfileData.sens
+                };
+              }
+            }
+          } catch (e) {
+            console.error("AI Eval: Error accessing client profile data:", e);
+            // Optionally inform the user or send a more basic payload
+            $('#ai-eval-status-area').append(`<p style="color: orange;">${client.translate('Warning: Could not retrieve full profile data for AI evaluation.')}</p>`);
+          }
+
+          storedData.sorteddaystoshow.forEach(function(dayString) {
+            var dayData = storedData.datastorage[dayString];
+            if (dayData && !dayData.treatmentsonly) {
+              if (dayData.sgv) {
+                dayData.sgv.forEach(s => cgmDataPayload.entries.push({ type: 'sgv', date: s.mills, sgv: s.sgv, direction: s.direction }));
+              }
+              if (dayData.mbg) {
+                dayData.mbg.forEach(m => cgmDataPayload.entries.push({ type: 'mbg', date: m.mills, mbg: m.mbg }));
+              }
+              if (dayData.treatments) {
+                dayData.treatments.forEach(t => {
+                  let treatmentEntry = {
+                    eventType: t.eventType, timestamp: t.timestamp, mills: t.mills, created_at: t.created_at,
+                  };
+                  if (t.carbs) treatmentEntry.carbs = t.carbs;
+                  if (t.insulin) treatmentEntry.insulin = t.insulin;
+                  if (t.notes) treatmentEntry.notes = t.notes;
+                  cgmDataPayload.treatments.push(treatmentEntry);
+                });
+              }
+            }
+          });
+
+          if (storedData.options && storedData.options.devicestatus) {
+            cgmDataPayload.deviceStatus = storedData.options.devicestatus;
+          } else if (datastorage.devicestatus) {
+            cgmDataPayload.deviceStatus = datastorage.devicestatus;
+          }
+
+          if (typeof client.triggerAIEvaluation === 'function') {
+            client.triggerAIEvaluation(cgmDataPayload);
+          } else {
+            console.error("AI Eval: triggerAIEvaluation function not found on client object.");
+            $('#ai-eval-results').html(`<p style="color: red;">${client.translate('Error: AI Evaluation trigger function is missing.')}</p>`);
+          }
+        } else {
+          // Config is valid, but data not fully loaded for this specific call.
+          // This message might briefly appear if report() is called multiple times by main client.
+          $('#ai-eval-results').html(client.translate('Waiting for all report data to load...'));
+        }
+      } else {
+        // currentConfigurationIsValid is false
+        // The message about invalid config should already be in $statusArea.
+        // $resultsDiv can reiterate or stay empty.
+        if ($('#ai-eval-status-area:contains("Configuration Incomplete")').length > 0) {
+             $('#ai-eval-results').html(client.translate('AI Evaluation cannot proceed until configuration issues (shown above) are resolved.'));
+        } else {
+            // This case implies config check hasn't run or failed silently.
+            // The try-catch in initial script load should provide clues.
+            $('#ai-eval-results').html(client.translate('AI Evaluation configuration not yet checked or is invalid. Activate the AI Evaluation tab to check settings.'));
+        }
+      }
     },
 
     html: function(client) {
-      var placeholderText = client.translate('AI evaluations will appear here. Click "Show AI Evaluation" after the main report data has loaded.');
-      var showButtonText = client.translate('Show AI Evaluation');
+      // var placeholderText = client.translate('AI evaluations will appear here. Click "Show AI Evaluation" after the main report data has loaded.');
+      // var showButtonText = client.translate('Show AI Evaluation');
       var html = `
-        <div id="ai-eval-content">
-          <p>${placeholderText}</p>
-          <button id="ai-eval-show-button" class="btn">${showButtonText}</button>
-          <div id="ai-eval-results" style="margin-top: 20px;">
-            <!-- LLM results will be displayed here -->
+        <div id="ai-eval-plugin-content"> <!-- Renamed parent for clarity -->
+          <div id="ai-eval-status-area" style="margin-bottom: 15px;">
+            <!-- Status messages like "All settings configured" or errors will go here -->
+          </div>
+          <div id="ai-eval-debug-info" style="margin-bottom: 15px;">
+            <!-- Debug info will be displayed here -->
+          </div>
+          <div id="ai-eval-results">
+            <!-- LLM results or loading messages will be displayed here -->
           </div>
         </div>
       `;
@@ -44,7 +154,7 @@ function init(ctx) {
     },
 
     css: `
-      #ai-eval-content {
+      #ai-eval-plugin-content { /* Adjusted selector */
         padding: 15px;
       }
       #ai-eval-results table {
@@ -74,177 +184,214 @@ function init(ctx) {
     `,
 
     script: function(client) {
-      const $showButton = $('#ai-eval-show-button');
+      // const $showButton = $('#ai-eval-show-button'); // Button removed
+      const $statusArea = $('#ai-eval-status-area');
       const $resultsDiv = $('#ai-eval-results');
+      const $debugInfoDiv = $('#ai-eval-debug-info');
       let serverPrompts = null; // To store fetched prompts
+      let currentConfigurationIsValid = false;
 
-      function checkConfigurationAndToggleButton() {
+      // This function will be called by the .report() function later
+      // For now, it's declared here.
+      // window.triggerAIEvaluation = function() { /* ... */ };
+
+
+      function performComprehensiveSettingsCheck(callback) {
+        $statusArea.html(client.translate('Checking AI configuration...'));
+        $resultsDiv.html(''); // Clear previous results or "waiting for data" messages
+        $debugInfoDiv.html(''); // Clear debug info
+
         let missingSettings = [];
-        let guidanceMessages = [];
 
-        // Check client-available settings (which reflect server ENV vars)
+        // 1. Check client-available settings (which reflect server ENV vars)
         if (!client.settings.ai_llm_api_url) {
-          missingSettings.push(client.translate('LLM API URL (AI_LLM_API_URL environment variable)'));
+          missingSettings.push({
+            item: client.translate('LLM API URL'),
+            hint: client.translate('Set AI_LLM_API_URL environment variable on your server.')
+          });
         }
         if (!client.settings.ai_llm_model) {
-          missingSettings.push(client.translate('LLM Model (AI_LLM_MODEL environment variable)'));
-        }
-        // AI_LLM_KEY is a server-side check, but we can remind the user about it.
-        // We can't confirm its presence from the client, but if others are missing, it's good to list.
-        if (!client.settings.ai_llm_api_url || !client.settings.ai_llm_model) { // If core URL/model missing, key is also critical
-             // No direct check for ai_llm_key on client for security, server handles this.
-             // But we can add a general reminder if other critical settings are missing.
-        }
-
-
-        // Check server-configured prompts
-        if (serverPrompts) {
-          if (!serverPrompts.system_prompt) {
-            missingSettings.push(client.translate('System Prompt (configure in Admin Tools > AI Evaluation Prompt Settings)'));
-          }
-          if (!serverPrompts.user_prompt_template) {
-            missingSettings.push(client.translate('User Prompt Template (configure in Admin Tools > AI Evaluation Prompt Settings, or set AI_LLM_PROMPT environment variable as fallback)'));
-          }
-        } else {
-          // If serverPrompts is null, it means the fetch hasn't completed or failed.
-          // We can add a generic message or wait for the fetch to complete.
-          // For now, if other things are missing, this will be covered.
-          // If fetch failed, an error message is already shown by fetchPromptsConfig.
-        }
-
-        if (missingSettings.length > 0) {
-          $showButton.prop('disabled', true);
-          let errorMessage = `<p style="color: red; font-weight: bold;">${client.translate('AI Evaluation Configuration Incomplete:')}</p>
-                            <p>${client.translate('The following configurations are missing or not set. Please configure them to enable AI Evaluation:')}</p>
-                            <ul style="color: red; margin-left: 20px;">`;
-          missingSettings.forEach(function(setting) {
-            errorMessage += `<li>${setting}</li>`;
+          missingSettings.push({
+            item: client.translate('LLM Model'),
+            hint: client.translate('Set AI_LLM_MODEL environment variable on your server.')
           });
-          errorMessage += `</ul>`;
-          if (!client.settings.ai_llm_key) { // Add a reminder for the key if other settings are missing
-            errorMessage += `<p style="color: orange;">${client.translate('Also ensure the AI_LLM_KEY environment variable is set on your server.')}</p>`;
-          }
-          $resultsDiv.html(errorMessage);
-          return false;
-        } else {
-          $showButton.prop('disabled', false);
-          // Clear previous error messages if any, but preserve loading/results message
-          if ($resultsDiv.find('p[style*="color: red"]').length > 0 || $resultsDiv.find('p[style*="color: orange"]').length > 0) {
-            //$resultsDiv.html(client.translate('Configuration complete. Ready to generate AI evaluation.'));
-          }
-          return true;
         }
-      }
+        // Note: AI_LLM_KEY is server-side only, but we add a general reminder if other things are missing.
 
-      function fetchPromptsConfig() {
-        $showButton.prop('disabled', true); // Disable button while checking
-        $resultsDiv.html(client.translate('Checking AI configuration...'));
-
+        // 2. Fetch server-configured prompts
         $.ajax({
           url: client.settings.baseURL + '/api/v1/ai_settings/prompts',
           type: 'GET',
           headers: client.headers(),
           success: function(data) {
             serverPrompts = data;
-            if (data && (data.system_prompt || data.user_prompt_template)) {
-              // console.log('AI Eval: Prompts fetched successfully.', data);
-            } else if (data && !data.system_prompt && !data.user_prompt_template && client.settings.ai_llm_prompt) {
-              // Prompts are empty in DB, but the fallback AI_LLM_PROMPT might be set on server.
-              // Server will handle this, so we can consider client-side check for prompts as "conditionally passed" if AI_LLM_PROMPT could be a factor.
-              // However, it's better to be explicit. The server API for /ai_eval already has robust fallback.
-              // For this check, we rely on what /api/v1/ai_settings/prompts returns.
-              // If both are empty, they are truly missing from primary config.
+            if (!data || !data.system_prompt) {
+              missingSettings.push({
+                item: client.translate('System Prompt'),
+                hint: client.translate('Configure in Admin Tools > AI Evaluation Prompt Settings.')
+              });
             }
-            checkConfigurationAndToggleButton();
+            if (!data || !data.user_prompt_template) {
+              // Check for fallback AI_LLM_PROMPT (though server /api/ai_eval handles this, good for UI feedback)
+              // The server API /api/v1/ai_settings/prompts returns empty strings if not set in DB.
+              // If client.settings.ai_llm_prompt (env var) is also not set, then it's truly missing.
+              // However, the primary source should be the DB for this check.
+              // The /api/v1/ai_eval will use env AI_LLM_PROMPT if DB user_prompt_template is empty.
+              // For frontend check, we primarily care if the specific DB fields are empty.
+              missingSettings.push({
+                item: client.translate('User Prompt Template'),
+                hint: client.translate('Configure in Admin Tools > AI Evaluation Prompt Settings (recommended), or set AI_LLM_PROMPT environment variable as a fallback.')
+              });
+            }
+
+            processSettingsCheckResult(missingSettings, callback);
           },
           error: function(jqXHR, textStatus, errorThrown) {
             console.error("Error fetching AI prompts configuration:", textStatus, errorThrown);
-            serverPrompts = { system_prompt: '', user_prompt_template: '' }; // Assume empty on error to show them as missing
-            $resultsDiv.html(`<p style="color: red;">${client.translate('Error checking AI prompt configuration: ')} ${textStatus}. ${client.translate('AI Evaluation may not function correctly.')}</p>`);
-            checkConfigurationAndToggleButton(); // Still run check to show other missing settings
+            // Assume prompts are missing if fetch fails, to guide user
+            missingSettings.push({
+              item: client.translate('System Prompt'),
+              hint: client.translate('Error fetching from server. Check Admin Tools > AI Evaluation Prompt Settings.')
+            });
+            missingSettings.push({
+              item: client.translate('User Prompt Template'),
+              hint: client.translate('Error fetching from server. Check Admin Tools > AI Evaluation Prompt Settings.')
+            });
+            $statusArea.html(`<p style="color: orange;">${client.translate('Could not verify prompt settings due to a server error. Please check server logs and Admin settings.')} (${textStatus})</p>`);
+            processSettingsCheckResult(missingSettings, callback, true); // Pass error flag
           }
         });
       }
 
+      function processSettingsCheckResult(missingSettings, callback, fetchError = false) {
+        if (missingSettings.length > 0) {
+          currentConfigurationIsValid = false;
+          let errorMessage = `<p style="color: red; font-weight: bold;">${client.translate('AI Evaluation Configuration Incomplete')}</p>
+                            <p>${client.translate('The following configurations are missing or not set. Please configure them to enable AI Evaluation:')}</p>
+                            <ul style="color: red; margin-left: 20px;">`;
+          missingSettings.forEach(function(setting) {
+            errorMessage += `<li>${client.escape(setting.item)}: <span style="font-style: italic;">${client.escape(setting.hint)}</span></li>`;
+          });
+          errorMessage += `</ul>`;
+
+          // Add reminder for AI_LLM_KEY if other critical settings are missing or if there was a fetch error for prompts
+          if (!client.settings.ai_llm_key_present_for_frontend_hint && (missingSettings.some(s => s.item.includes("URL") || s.item.includes("Model")) || fetchError) ) {
+             // The 'ai_llm_key_present_for_frontend_hint' is a hypothetical setting to indicate if the key is set for hint purposes.
+             // Since we can't directly check the key, we rely on its absence being a common issue.
+             // A more robust way would be for the server to pass a boolean `isApiKeySet` via client.settings if desired,
+             // but that also has security implications if not handled carefully.
+             // For now, a general hint is provided if core settings are missing.
+            errorMessage += `<p style="color: orange; margin-top:10px;">${client.translate('Reminder: Also ensure the AI_LLM_KEY environment variable is correctly set on your server. This cannot be checked by the browser.')}</p>`;
+          }
+
+          $statusArea.html(errorMessage); // Display detailed errors in status area
+          $resultsDiv.html(''); // Clear results area
+          $debugInfoDiv.html(''); // Clear debug area
+          // Hide other UI elements if necessary (though button is already gone)
+        } else {
+          currentConfigurationIsValid = true;
+          $statusArea.html(`<p style="color: green;">${client.translate('All LLM Settings are configured correctly.')}</p>`);
+          // $resultsDiv.html(client.translate('Waiting for main report data to trigger AI evaluation...')); // This will be set by report()
+        }
+
+        if (callback && typeof callback === 'function') {
+          callback(currentConfigurationIsValid);
+        }
+      }
+
+
       // Initial check when the script loads / tab is shown
-      fetchPromptsConfig();
+      // This function will be called by the report() function when data is available.
+      // For now, we'll call it once on load to display status.
+      // The actual evaluation trigger will be handled by report().
+      try {
+        performComprehensiveSettingsCheck(function(isValid) {
+          if (isValid) {
+            // If config is valid on initial load, prompt user or indicate readiness.
+            $resultsDiv.html(client.translate('AI settings are valid. AI evaluation will automatically start once main report data is loaded.'));
+          } else {
+            // Error message is already displayed by performComprehensiveSettingsCheck in $statusArea.
+            // Set a clear message in $resultsDiv too if config is invalid from the start.
+            if ($('#ai-eval-status-area:contains("Configuration Incomplete")').length > 0) {
+                 $('#ai-eval-results').html(client.translate('AI Evaluation cannot proceed until configuration issues (shown above) are resolved.'));
+            } else {
+                 // Fallback if status area somehow didn't get the error message
+                 $('#ai-eval-results').html(client.translate('AI Evaluation configuration is incomplete. Please check settings.'));
+            }
+          }
+        });
+      } catch (e) {
+          console.error("AI Eval Plugin: Error during initial settings check:", e);
+          $statusArea.html(`<p style="color: red;">${client.translate('Critical error during AI Plugin initialization:')} ${client.escape(e.message)}</p>`);
+          $resultsDiv.html(client.translate('Plugin failed to initialize. Check console for details.'));
+          currentConfigurationIsValid = false; // Ensure this is false
+      }
 
 
-      $showButton.on('click', function() {
-        if (!checkConfigurationAndToggleButton()) {
-          // Re-check just in case, and prevent submission if still not configured.
+      // The old button click handler is removed.
+      // The logic for making the AJAX call will be moved to a new function
+      // called by report() if settings are valid and data is present.
+
+      // Placeholder for the function that will be called by report()
+      // This will be fleshed out in the next step of the plan.
+      // For now, this script block focuses on settings checks and UI updates on load.
+      client.triggerAIEvaluation = function(cgmDataPayload) {
+        if (!currentConfigurationIsValid) {
+          $resultsDiv.html(`<p style="color: red;">${client.translate('Cannot trigger AI Evaluation: Configuration is invalid. Please check messages above.')}</p>`);
           return;
         }
 
         $resultsDiv.html(client.translate('Loading AI evaluation...'));
+        $debugInfoDiv.html(''); // Clear previous debug info
+        // Status area might show "all configured", which is fine. Or we can add "Loading..." there too.
 
-        if (!storedData.datastorage || !storedData.sorteddaystoshow || !storedData.options) {
-          $resultsDiv.html(`<p style="color: red;">${client.translate('Report data not loaded yet. Please click the main "Show" button for the reports first.')}</p>`);
-          return;
-        }
-
-        // Server-side settings (like AI_LLM_KEY) are validated by the /api/v1/ai_eval endpoint.
-        // Client-side checks for URL and Model are already done by checkConfigurationAndToggleButton.
-
-        var daysData = [];
-        storedData.sorteddaystoshow.forEach(function(dayString) {
-          var dayData = storedData.datastorage[dayString];
-          if (dayData && !dayData.treatmentsonly) { // treatmentsonly days are for previous day's treatments, not full days
-            daysData.push({
-              date: dayString,
-              sgv: dayData.sgv ? dayData.sgv.map(function(s) { return { sgv: s.sgv, mills: s.mills, type: s.type }; }) : [],
-              treatments: dayData.treatments ? dayData.treatments.map(function(t) { return { eventType: t.eventType, carbs: t.carbs, insulin: t.insulin, mills: t.mills }; }) : [],
-              dailyCarbs: dayData.dailyCarbs
-            });
-          }
-        });
-
-        var payload = {
-          reportOptions: {
-            targetLow: storedData.options.targetLow,
-            targetHigh: storedData.options.targetHigh,
-            units: storedData.options.units,
-            dateFrom: storedData.sorteddaystoshow.length > 0 ? storedData.sorteddaystoshow[0] : null,
-            dateTo: storedData.sorteddaystoshow.length > 0 ? storedData.sorteddaystoshow[storedData.sorteddaystoshow.length - 1] : null,
-          },
-          daysData: daysData,
-          prompt: llmPrompt
-        };
-
-        // console.log('AI Eval: Sending payload to /api/v1/ai_eval', payload);
-
+        // The payload to /api/v1/ai_eval is just the cgmDataPayload.
+        // The server will combine this with configured prompts.
         $.ajax({
-          url: client.settings.baseURL + '/api/v1/ai_eval', // Ensure baseURL is prepended
+          url: client.settings.baseURL + '/api/v1/ai_eval',
           type: 'POST',
           contentType: 'application/json',
-          data: JSON.stringify(payload),
-          headers: client.headers(), // For authentication if needed
+          data: JSON.stringify(cgmDataPayload), // This is the data for {{CGMDATA}}
+          headers: client.headers(),
           success: function(response) {
-            // Assuming the response is HTML or Markdown that can be directly injected.
-            // For Markdown, a client-side parser might be needed if not pre-rendered.
-            // For now, let's assume it's HTML.
-            let finalHtml = '';
-            if (client.settings.ai_llm_debug && response && response.debug_prompts) {
-              const debug = response.debug_prompts;
-              finalHtml += `
-                <div style="background-color: #f0f0f0; border: 1px solid #ccc; padding: 10px; margin-bottom: 15px;">
-                  <h4 style="margin-top:0;">${client.translate('AI Debug Info:')}</h4>
-                  <p><strong>${client.translate('Model:')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.model || 'N/A')}</pre></p>
-                  <p><strong>${client.translate('System Prompt:')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.system || 'N/A')}</pre></p>
-                  <p><strong>${client.translate('User Prompt Template:')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.user_template || 'N/A')}</pre></p>
-                  <p><strong>${client.translate('Final User Prompt (with data):')}</strong> <pre style="white-space: pre-wrap; word-break: break-all;">${client.escape(debug.user_final || 'N/A')}</pre></p>
-                </div>
-              `;
+            let finalResultsHtml = '';
+            let finalDebugHtml = '';
+
+            if (client.settings.ai_llm_debug && response && response.debug_info) {
+              const debug = response.debug_info;
+              // Using a more structured display for debug info, perhaps with <pre> for prompts
+              finalDebugHtml += `<h4 style="margin-top:0;">${client.translate('AI Debug Info:')}</h4>`;
+              finalDebugHtml += `<p><strong>${client.translate('Model:')}</strong> ${client.escape(debug.model || 'N/A')}</p>`;
+
+              finalDebugHtml += `<p><strong>${client.translate('System Prompt:')}</strong></p><pre style="white-space: pre-wrap; word-break: break-all; background-color: #f8f8f8; border: 1px solid #ddd; padding: 5px;">${client.escape(debug.system_prompt || 'N/A')}</pre>`;
+
+              // User Prompt Template is what's stored (with {{CGMDATA}})
+              // finalDebugHtml += `<p><strong>${client.translate('User Prompt Template:')}</strong></p><pre style="white-space: pre-wrap; word-break: break-all; background-color: #f8f8f8; border: 1px solid #ddd; padding: 5px;">${client.escape(debug.user_prompt_template || 'N/A')}</pre>`;
+
+              finalDebugHtml += `<p><strong>${client.translate('Final User Prompt (with data injected):')}</strong></p><pre style="white-space: pre-wrap; word-break: break-all; background-color: #f8f8f8; border: 1px solid #ddd; padding: 5px;">${client.escape(debug.final_user_prompt || 'N/A')}</pre>`;
+
+              $debugInfoDiv.html(finalDebugHtml).show();
+            } else {
+              $debugInfoDiv.hide();
             }
 
             if (response && response.html_content) {
-              finalHtml += response.html_content;
-            } else if (typeof response === 'string' && (!response.debug_prompts)) { // if it's just a string and not our debug object
-              finalHtml += response; // Fallback if response is just a string
-            } else if (!response || !response.html_content) {
-               finalHtml += `<p>${client.translate('Received an empty or unexpected LLM response from the server.')}</p>`;
+              finalResultsHtml += response.html_content;
+            } else {
+              finalResultsHtml += `<p>${client.translate('Received an empty or unexpected LLM response from the server.')}</p>`;
             }
-            $('#ai-eval-results').html(finalHtml);
+
+            if (response && response.tokens_used) {
+                const costMessage = client.translate('Tokens used for this evaluation:') + ' ' + response.tokens_used;
+                // Display cost message. Could be in $statusArea or appended to $resultsDiv
+                if ($statusArea.find('p[style*="color: green"]').length > 0) { // If "all configured" message is there
+                    $statusArea.append(`<p><small>${costMessage}</small></p>`);
+                } else {
+                    finalResultsHtml += `<hr><p><small>${costMessage}</small></p>`;
+                }
+            }
+
+            $resultsDiv.html(finalResultsHtml);
           },
           error: function(jqXHR, textStatus, errorThrown) {
             console.error('AI Eval Error:', textStatus, errorThrown, jqXHR.responseText);
@@ -254,19 +401,20 @@ function init(ctx) {
             } else if (jqXHR.responseText) {
               try {
                 var parsedError = JSON.parse(jqXHR.responseText);
-                if(parsedError && parsedError.error) {
+                if (parsedError && parsedError.error) {
                   errorMsg += ' - ' + client.translate(parsedError.error);
                 } else {
-                   errorMsg += ' - ' + client.translate('Check server logs for details.');
+                  errorMsg += ' - ' + client.translate('Check server logs for details.');
                 }
-              } catch(e) {
-                 errorMsg += ' - ' + client.translate('Unparseable error from server. Check server logs.');
+              } catch (e) {
+                errorMsg += ' - ' + client.translate('Unparseable error from server. Check server logs.');
               }
             }
-            $('#ai-eval-results').html(`<p style="color: red;">${errorMsg}</p>`);
+            $resultsDiv.html(`<p style="color: red;">${errorMsg}</p>`);
+            $debugInfoDiv.hide();
           }
         });
-      });
+      };
     }
   };
 


### PR DESCRIPTION
This commit addresses two primary issues:

1.  **Main report rendering interference:**
    - The AI Evaluation plugin's `report` function no longer makes a direct asynchronous call to check settings.
    - It now relies on a configuration validity flag (`currentConfigurationIsValid`) that is set when the AI Evaluation tab's script is initially loaded.
    - This prevents the AI plugin from delaying or blocking the completion of the main report rendering cycle, resolving the issue where the "Rendering..." text would not disappear on other report tabs.

2.  **AI Tab missing configuration error display:**
    - Added `try...catch` blocks around the initial settings check (`performComprehensiveSettingsCheck`) execution within the plugin's script. This ensures that any JavaScript errors during initialization are caught and displayed, preventing silent failures that might have hidden configuration error messages.
    - Added a `try...catch` block around `client.profile()` access during data preparation for increased robustness, with a warning message if profile data is inaccessible.
    - Refined messages in the results area to be clearer if the configuration is invalid from the start.

These changes should ensure that the main Nightscout reporting UI functions correctly and that the AI Evaluation tab reliably displays errors for missing configurations like API URL or Model.