### PR TITLE
feat(ai-eval): Add 14-day limit to AI evaluation report

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -91,6 +91,7 @@ A new section in Admin Tools allows you to monitor LLM usage:
 
 1.  **Navigate to Reports:** Go to the "Reports" section of your Nightscout site.
 2.  **Load Report Data:** Select any standard report type (e.g., "Day to day," "Daily Stats"), choose your desired date range and other relevant filters, and click the main "Show" button for the reports. This action loads the data that will be available for the AI evaluation.
+    *   **Important:** The AI Evaluation is limited to a maximum of **14 days**. If you select a longer period, the "Send to AI" button will be disabled, and a message will prompt you to reduce the date range. This is to ensure good performance and manage LLM usage costs.
 3.  **Open AI Evaluation Tab:** In the list of report tabs, click on "AI Evaluation".
     *   Upon opening the tab, the plugin will automatically check for all required configurations (API URL, Model, System Prompt, User Prompt Template).
     *   If any settings are missing, a detailed error message will be displayed, guiding you on where to configure each item.

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -731,6 +731,35 @@ function init(ctx) {
 
                             }
 
+                            // Check if the number of days exceeds the limit
+                            if (cgmData.days.length > 14) {
+                                const sendButton = document.getElementById('sendToAiButton');
+                                if (sendButton) {
+                                    sendButton.disabled = true;
+                                }
+                                const responseOutputArea = document.getElementById('aiResponseOutputArea');
+                                if (responseOutputArea) {
+                                    responseOutputArea.innerHTML = '<p style="color: red; font-weight: bold;">The selected period is too long. Please reduce the amount of days to 14 or less to use the AI Evaluation.</p>';
+                                }
+                                // Clear debug areas and stop further processing
+                                const interimDebugArea = document.getElementById('aiEvalInterimDebugArea');
+                                if (interimDebugArea) interimDebugArea.textContent = 'Processing stopped: Date range exceeds 14 days.';
+                                const debugArea = document.getElementById('aiEvalDebugArea');
+                                if (debugArea) debugArea.textContent = '';
+
+                                // Clean up temporary global data, as we are aborting.
+                                if (typeof window !== 'undefined' && window.tempAiEvalReportData) {
+                                    delete window.tempAiEvalReportData;
+                                }
+                                return; // Stop processing
+                            } else {
+                                // Explicitly enable the button if the date range is valid, in case it was disabled previously.
+                                const sendButton = document.getElementById('sendToAiButton');
+                                if (sendButton) {
+                                    sendButton.disabled = false;
+                                }
+                            }
+
                             function dateToDDMMYYYY(date) {
                                 const dd = String(date.getDate()).padStart(2, '0');
                                 const mm = String(date.getMonth() + 1).padStart(2, '0'); // Monate: 0-basiert


### PR DESCRIPTION
This commit introduces a limitation on the AI Evaluation report, restricting the analysis to a maximum of 14 days.

- In `lib/report_plugins/ai_eval.js`, a check is added to determine the number of days selected for the report.
- If the period is longer than 14 days, the "Send to AI" button is disabled, and an error message is displayed to you.
- The `ai_evaluation.md` documentation has been updated to inform you of this new limitation.