### PR TITLE
fix(ai-eval): Reset prompt status when date range is invalid

### DIFF
--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -741,6 +741,13 @@ function init(ctx) {
                                 if (responseOutputArea) {
                                     responseOutputArea.innerHTML = '<p style="color: red; font-weight: bold;">The selected period is too long. Please reduce the amount of days to 14 or less to use the AI Evaluation.</p>';
                                 }
+                                // Reset prompt statuses
+                                const $ = window.jQuery;
+                                $('#ai-system-interim-prompt-status').text('Not Set').removeClass('ai-setting-value-set ai-setting-value-loading').addClass('ai-setting-value-not-set');
+                                $('#ai-user-interim-prompt-status').text('Not Set').removeClass('ai-setting-value-set ai-setting-value-loading').addClass('ai-setting-value-not-set');
+                                $('#ai-system-prompt-status').text('Not Set').removeClass('ai-setting-value-set ai-setting-value-loading').addClass('ai-setting-value-not-set');
+                                $('#ai-user-prompt-status').text('Not Set').removeClass('ai-setting-value-set ai-setting-value-loading').addClass('ai-setting-value-not-set');
+
                                 // Clear debug areas and stop further processing
                                 const interimDebugArea = document.getElementById('aiEvalInterimDebugArea');
                                 if (interimDebugArea) interimDebugArea.textContent = 'Processing stopped: Date range exceeds 14 days.';


### PR DESCRIPTION
I've fixed a UI bug where the prompt statuses would remain as "Set" after you selected a date range longer than the 14-day limit.

- I updated the logic in `lib/report_plugins/ai_eval.js` to also reset the four prompt status indicators to "Not Set" when the 14-day check fails. This provides clearer feedback to you that the prompts are not being used for the invalid selection.