### PR TITLE
feat(ai-eval): Display detailed token usage statistics

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -129,27 +129,9 @@ function create (env, ctx) {
 
                 const clientResponse = {
                     html_content: contentToReturn,
-                    tokens_used: llmResponse.usage ? llmResponse.usage.total_tokens : 0
+                    // Pass the whole usage object. Provide a default if it's missing.
+                    usage: llmResponse.usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
                 };
-
-                if (llmResponse.usage && typeof llmResponse.usage.total_tokens === 'number') {
-                    const tokensConsumed = llmResponse.usage.total_tokens;
-                    const internalRecordPayload = { tokens_used: tokensConsumed };
-                    request({
-                        uri: `${req.protocol}://${req.get('host')}/api/v1/ai_usage/record`,
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            ...(ctx.headers ? ctx.headers() : (req.headers.authorization ? { 'Authorization': req.headers.authorization } : (req.headers['api-secret'] ? { 'api-secret': req.headers['api-secret'] } : {})))
-                        },
-                        body: JSON.stringify(internalRecordPayload)
-                    }, (err, recordRes, recordBody) => {
-                        if (err) console.error('[AI_EVAL] Error calling /ai_usage/record:', err.message);
-                        else if (recordRes.statusCode < 200 || recordRes.statusCode >= 300) console.error(`[AI_EVAL] Error recording usage: status ${recordRes.statusCode}`, recordBody);
-                    });
-                } else {
-                    console.warn('[AI_EVAL] LLM response did not include usage.total_tokens. Usage not recorded.');
-                }
 
                 res.json(clientResponse);
             } else {

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -193,7 +193,7 @@ function init(ctx) {
 
                                     return {
                                         html_content: parsed,
-                                        tokens_used: response.tokens_used
+                                        usage: response.usage
                                     };
                                 }
                             } catch (e) {
@@ -201,7 +201,7 @@ function init(ctx) {
                                 return {
                                     error: 'Failed to parse html_content',
                                     original_content: response.html_content,
-                                    tokens_used: response.tokens_used
+                                    usage: response.usage
                                 };
                             }
                             return null;
@@ -237,8 +237,9 @@ function init(ctx) {
                                         content: parsedContent
                                     });
 
-                                    totalTokensUsed += response.tokens_used || 0;
-                                    interimCallTokens += response.tokens_used || 0;
+                                    const usage = response.usage || {};
+                                    totalTokensUsed += usage.total_tokens || 0;
+                                    interimCallTokens += usage.total_tokens || 0;
                                     interimCallsAmount++;
                                 }
                             } catch (e) {
@@ -358,7 +359,8 @@ function init(ctx) {
 
                                 // Update aiResponsesDataObject
                                 if (window.aiResponsesDataObject) {
-                                    window.aiResponsesDataObject.total_tokens_used += finalData.tokens_used || 0;
+                                    const finalUsage = finalData.usage || { total_tokens: 0, prompt_tokens: 0, completion_tokens: 0 };
+                                    window.aiResponsesDataObject.total_tokens_used += finalUsage.total_tokens || 0;
                                     window.aiResponsesDataObject.final_response = finalData.html_content;
                                     window.aiResponsesDataObject.total_calls = (window.aiResponsesDataObject.interim_calls_amount || 0) + 1;
                                     window.aiResponsesDataObject.final_call = 1;
@@ -367,10 +369,14 @@ function init(ctx) {
                                     responseOutputArea.innerHTML = finalData.html_content;
                                     statisticsArea.innerHTML = `
                                         <p><strong>Statistics for ${window.aiResponsesDataObject.date_from} - ${window.aiResponsesDataObject.date_till}</strong><br>
-                                        Total Tokens Used: ${window.aiResponsesDataObject.total_tokens_used}<br>
-                                        Total API Calls: ${window.aiResponsesDataObject.total_calls}<br>
-                                        Interim Calls: ${window.aiResponsesDataObject.interim_calls_amount}<br>
-                                        Final Call: ${window.aiResponsesDataObject.final_call}
+                                        <strong>Total API Calls: ${window.aiResponsesDataObject.total_calls}</strong> (Interim: ${window.aiResponsesDataObject.interim_calls_amount}, Final: 1)<br>
+                                        <br>
+                                        <strong>Final Call Usage:</strong><br>
+                                        - Prompt Tokens: ${finalUsage.prompt_tokens || 'N/A'}<br>
+                                        - Completion Tokens: ${finalUsage.completion_tokens || 'N/A'}<br>
+                                        - Total: ${finalUsage.total_tokens || 'N/A'}<br>
+                                        <br>
+                                        <strong>Overall Total Tokens Used: ${window.aiResponsesDataObject.total_tokens_used}</strong>
                                         </p>
                                     `;
 


### PR DESCRIPTION
This commit enhances the AI Evaluation feature to provide a more detailed breakdown of token usage for each API call.

- The backend (`/api/v1/ai_eval`) has been updated to pass the complete `usage` object from the LLM response to the client, rather than just the total tokens.
- A redundant and incorrect server-side call to record usage has been removed.
- The frontend (`ai_eval.js`) has been updated to parse the new `usage` object.
- The statistics display now shows a clear breakdown of prompt, completion, and total tokens for the final AI call, providing better insight for debugging and cost monitoring.