### PR TITLE
feat(stats): Implement detailed token usage statistics

### DIFF
--- a/lib/admin_plugins/ai_usage_viewer.js
+++ b/lib/admin_plugins/ai_usage_viewer.js
@@ -16,16 +16,27 @@ function init(ctx) {
         }
 
         let tableHtml = `
-      <table class="table-ai-usage" style="width: auto;">
+      <table class="table-ai-usage" style="width: auto; border-collapse: collapse;">
         <thead>
           <tr>
-            <th>${client.translate('Month')}</th>
-            <th>${client.translate('Requests')}</th>
-            <th>${client.translate('Total Days')}</th>
-            <th>${client.translate('Avg Days/Req')}</th>
-            <th>${client.translate('Total Tokens')}</th>
-            <th>${client.translate('Avg Tokens/Req')}</th>
-            <th>${client.translate('Avg Tokens/Day')}</th>
+            <th rowspan="2" style="vertical-align: bottom;">${client.translate('Month')}</th>
+            <th rowspan="2" style="vertical-align: bottom;">${client.translate('Requests')}</th>
+            <th rowspan="2" style="vertical-align: bottom;">${client.translate('Total Days')}</th>
+            <th rowspan="2" style="vertical-align: bottom;">${client.translate('Avg Days/Req')}</th>
+            <th colspan="3">${client.translate('Total Tokens')}</th>
+            <th colspan="3">${client.translate('Avg Tokens/Req')}</th>
+            <th colspan="3">${client.translate('Avg Tokens/Day')}</th>
+          </tr>
+          <tr>
+            <th>${client.translate('Input')}</th>
+            <th>${client.translate('Output')}</th>
+            <th>${client.translate('Total')}</th>
+            <th>${client.translate('Input')}</th>
+            <th>${client.translate('Output')}</th>
+            <th>${client.translate('Total')}</th>
+            <th>${client.translate('Input')}</th>
+            <th>${client.translate('Output')}</th>
+            <th>${client.translate('Total')}</th>
           </tr>
         </thead>
         <tbody>
@@ -38,8 +49,17 @@ function init(ctx) {
           <td>${monthEntry.requests}</td>
           <td>${monthEntry.total_days_requested}</td>
           <td>${parseFloat(monthEntry.avg_days_per_request).toFixed(2)}</td>
+
+          <td>${monthEntry.total_prompt_tokens}</td>
+          <td>${monthEntry.total_completion_tokens}</td>
           <td>${monthEntry.total_tokens}</td>
+
+          <td>${parseFloat(monthEntry.avg_prompt_tokens_per_request).toFixed(0)}</td>
+          <td>${parseFloat(monthEntry.avg_completion_tokens_per_request).toFixed(0)}</td>
           <td>${parseFloat(monthEntry.avg_tokens_per_request).toFixed(0)}</td>
+
+          <td>${parseFloat(monthEntry.avg_prompt_tokens_per_day).toFixed(0)}</td>
+          <td>${parseFloat(monthEntry.avg_completion_tokens_per_day).toFixed(0)}</td>
           <td>${parseFloat(monthEntry.avg_tokens_per_day).toFixed(0)}</td>
         </tr>
       `;
@@ -53,8 +73,17 @@ function init(ctx) {
             <td>${totalData.requests || 0}</td>
             <td>${totalData.total_days_requested || 0}</td>
             <td>${parseFloat(totalData.avg_days_per_request || 0).toFixed(2)}</td>
+
+            <td>${totalData.total_prompt_tokens || 0}</td>
+            <td>${totalData.total_completion_tokens || 0}</td>
             <td>${totalData.total_tokens || 0}</td>
+
+            <td>${parseFloat(totalData.avg_prompt_tokens_per_request || 0).toFixed(0)}</td>
+            <td>${parseFloat(totalData.avg_completion_tokens_per_request || 0).toFixed(0)}</td>
             <td>${parseFloat(totalData.avg_tokens_per_request || 0).toFixed(0)}</td>
+
+            <td>${parseFloat(totalData.avg_prompt_tokens_per_day || 0).toFixed(0)}</td>
+            <td>${parseFloat(totalData.avg_completion_tokens_per_day || 0).toFixed(0)}</td>
             <td>${parseFloat(totalData.avg_tokens_per_day || 0).toFixed(0)}</td>
           </tr>
         </tfoot>

--- a/lib/api/ai_usage_api.js
+++ b/lib/api/ai_usage_api.js
@@ -11,12 +11,14 @@ function configure(app, wares, ctx) {
   api.use(wares.sendJSONStatus);
 
   api.post('/record', ctx.authorization.isPermitted('api:treatments:read'), async (req, res) => {
-    const { date_from, date_till, days_requested, total_tokens_used, total_api_calls } = req.body;
+    const { date_from, date_till, days_requested, prompt_tokens_used, completion_tokens_used, total_tokens_used, total_api_calls } = req.body;
 
     if (
         !date_from ||
         !date_till ||
         typeof days_requested !== 'number' ||
+        typeof prompt_tokens_used !== 'number' ||
+        typeof completion_tokens_used !== 'number' ||
         typeof total_tokens_used !== 'number' ||
         typeof total_api_calls !== 'number'
     ) {
@@ -30,6 +32,8 @@ function configure(app, wares, ctx) {
         date_from,
         date_till,
         days_requested,
+        prompt_tokens_used,
+        completion_tokens_used,
         total_tokens_used,
         total_api_calls,
       };
@@ -57,6 +61,8 @@ function configure(app, wares, ctx) {
           $project: {
             month: { $dateToString: { format: "%Y-%m", date: "$createdAt" } },
             days_requested: 1,
+            prompt_tokens_used: { $ifNull: ["$prompt_tokens_used", 0] },
+            completion_tokens_used: { $ifNull: ["$completion_tokens_used", 0] },
             total_tokens_used: 1,
             total_api_calls: 1
           }
@@ -66,6 +72,8 @@ function configure(app, wares, ctx) {
             _id: "$month",
             requests: { $sum: 1 },
             total_days_requested: { $sum: "$days_requested" },
+            total_prompt_tokens: { $sum: "$prompt_tokens_used" },
+            total_completion_tokens: { $sum: "$completion_tokens_used" },
             total_tokens: { $sum: "$total_tokens_used" }
           }
         },
@@ -76,8 +84,17 @@ function configure(app, wares, ctx) {
             requests: 1,
             total_days_requested: 1,
             avg_days_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_days_requested", "$requests"] } } },
+
+            total_prompt_tokens: 1,
+            total_completion_tokens: 1,
             total_tokens: 1,
+
+            avg_prompt_tokens_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_prompt_tokens", "$requests"] } } },
+            avg_completion_tokens_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_completion_tokens", "$requests"] } } },
             avg_tokens_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_tokens", "$requests"] } } },
+
+            avg_prompt_tokens_per_day: { $cond: { if: { $eq: ["$total_days_requested", 0] }, then: 0, else: { $divide: ["$total_prompt_tokens", "$total_days_requested"] } } },
+            avg_completion_tokens_per_day: { $cond: { if: { $eq: ["$total_days_requested", 0] }, then: 0, else: { $divide: ["$total_completion_tokens", "$total_days_requested"] } } },
             avg_tokens_per_day: { $cond: { if: { $eq: ["$total_days_requested", 0] }, then: 0, else: { $divide: ["$total_tokens", "$total_days_requested"] } } }
           }
         },
@@ -92,6 +109,8 @@ function configure(app, wares, ctx) {
             _id: "all_time",
             requests: { $sum: 1 },
             total_days_requested: { $sum: "$days_requested" },
+            total_prompt_tokens: { $sum: { $ifNull: ["$prompt_tokens_used", 0] } },
+            total_completion_tokens: { $sum: { $ifNull: ["$completion_tokens_used", 0] } },
             total_tokens: { $sum: "$total_tokens_used" }
           }
         },
@@ -101,8 +120,17 @@ function configure(app, wares, ctx) {
             requests: 1,
             total_days_requested: 1,
             avg_days_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_days_requested", "$requests"] } } },
+
+            total_prompt_tokens: 1,
+            total_completion_tokens: 1,
             total_tokens: 1,
+
+            avg_prompt_tokens_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_prompt_tokens", "$requests"] } } },
+            avg_completion_tokens_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_completion_tokens", "$requests"] } } },
             avg_tokens_per_request: { $cond: { if: { $eq: ["$requests", 0] }, then: 0, else: { $divide: ["$total_tokens", "$requests"] } } },
+
+            avg_prompt_tokens_per_day: { $cond: { if: { $eq: ["$total_days_requested", 0] }, then: 0, else: { $divide: ["$total_prompt_tokens", "$total_days_requested"] } } },
+            avg_completion_tokens_per_day: { $cond: { if: { $eq: ["$total_days_requested", 0] }, then: 0, else: { $divide: ["$total_completion_tokens", "$total_days_requested"] } } },
             avg_tokens_per_day: { $cond: { if: { $eq: ["$total_days_requested", 0] }, then: 0, else: { $divide: ["$total_tokens", "$total_days_requested"] } } }
           }
         }

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -210,6 +210,8 @@ function init(ctx) {
                         const parsedResponses = [];
 
                         let totalTokensUsed = 0;
+                        let totalPromptTokens = 0;
+                        let totalCompletionTokens = 0;
                         let interimCallTokens = 0;
                         let interimCallsAmount = 0;
 
@@ -239,6 +241,8 @@ function init(ctx) {
 
                                     const usage = response.usage || {};
                                     totalTokensUsed += usage.total_tokens || 0;
+                                    totalPromptTokens += usage.prompt_tokens || 0;
+                                    totalCompletionTokens += usage.completion_tokens || 0;
                                     interimCallTokens += usage.total_tokens || 0;
                                     interimCallsAmount++;
                                 }
@@ -268,6 +272,8 @@ function init(ctx) {
                             interim_call_tokens: interimCallTokens,
                             interim_calls_amount: interimCallsAmount,
                             total_tokens_used: totalTokensUsed,
+                            prompt_tokens_used: totalPromptTokens,
+                            completion_tokens_used: totalCompletionTokens,
                             date_from: date_from,
                             date_till: date_till
                         };
@@ -360,7 +366,12 @@ function init(ctx) {
                                 // Update aiResponsesDataObject
                                 if (window.aiResponsesDataObject) {
                                     const finalUsage = finalData.usage || { total_tokens: 0, prompt_tokens: 0, completion_tokens: 0 };
+
+                                    // Add final call's token usage to the totals
                                     window.aiResponsesDataObject.total_tokens_used += finalUsage.total_tokens || 0;
+                                    window.aiResponsesDataObject.prompt_tokens_used += finalUsage.prompt_tokens || 0;
+                                    window.aiResponsesDataObject.completion_tokens_used += finalUsage.completion_tokens || 0;
+
                                     window.aiResponsesDataObject.final_response = finalData.html_content;
                                     window.aiResponsesDataObject.total_calls = (window.aiResponsesDataObject.interim_calls_amount || 0) + 1;
                                     window.aiResponsesDataObject.final_call = 1;
@@ -376,7 +387,10 @@ function init(ctx) {
                                         - Completion Tokens: ${finalUsage.completion_tokens || 'N/A'}<br>
                                         - Total: ${finalUsage.total_tokens || 'N/A'}<br>
                                         <br>
-                                        <strong>Overall Total Tokens Used: ${window.aiResponsesDataObject.total_tokens_used}</strong>
+                                        <strong>Overall Session Usage:</strong><br>
+                                        - Prompt Tokens: ${window.aiResponsesDataObject.prompt_tokens_used}<br>
+                                        - Completion Tokens: ${window.aiResponsesDataObject.completion_tokens_used}<br>
+                                        - Total Tokens: ${window.aiResponsesDataObject.total_tokens_used}
                                         </p>
                                     `;
 
@@ -385,6 +399,8 @@ function init(ctx) {
                                         date_from: window.aiResponsesDataObject.date_from,
                                         date_till: window.aiResponsesDataObject.date_till,
                                         days_requested: window.aiResponsesDataObject.interim_calls_amount,
+                                        prompt_tokens_used: window.aiResponsesDataObject.prompt_tokens_used,
+                                        completion_tokens_used: window.aiResponsesDataObject.completion_tokens_used,
                                         total_tokens_used: window.aiResponsesDataObject.total_tokens_used,
                                         total_api_calls: window.aiResponsesDataObject.total_calls,
                                     };


### PR DESCRIPTION
This commit introduces a major enhancement to the AI Usage Statistics feature, providing a detailed breakdown of token consumption.

- The client-side script (`ai_eval.js`) now aggregates prompt, completion, and total tokens for the entire evaluation session (including all interim calls and the final call).
- The payload sent to the usage recording endpoint now includes this detailed breakdown.
- The backend API (`ai_usage_api.js`) has been updated:
  - The `/record` endpoint now saves the detailed token counts to the database.
  - The `/monthly_summary` endpoint features rewritten aggregation pipelines to calculate sums and averages for prompt, completion, and total tokens. This change is backward-compatible with older data entries.
- The Admin UI (`ai_usage_viewer.js`) has been overhauled to display the new statistics in a more detailed table, with new columns for Input/Output tokens and their corresponding averages.