### PR TITLE
fix: Correctly access settings in AI usage API

### DIFF
--- a/lib/api/ai_usage_api.js
+++ b/lib/api/ai_usage_api.js
@@ -53,12 +53,11 @@ function configure(app, wares, ctx) {
   });
 
   api.get('/monthly_summary', ctx.authorization.isPermitted('api:treatments:read'), async (req, res) => {
-    console.log('AI Eval: REQ within monthly summary API', req);
     try {
       const usageCollection = ctx.store.collection(USAGE_COLLECTION_NAME);
 
-      const cost_input = req.settings.ai_llm_1k_token_costs_input;
-      const cost_output = req.settings.ai_llm_1k_token_costs_output;
+      const cost_input = ctx.settings.ai_llm_1k_token_costs_input;
+      const cost_output = ctx.settings.ai_llm_1k_token_costs_output;
 
       const monthlyPipeline = [
         {


### PR DESCRIPTION
This commit fixes a persistent 500 Internal Server Error in the `/api/v1/ai_usage/monthly_summary` endpoint.

The root cause of the error was that the handler was attempting to read settings from `req.settings`, but the settings are not attached to the `req` object in this part of the API. With your help, it was determined that the settings are available on the `ctx` (context) object.

This commit changes the code to read the cost settings from `ctx.settings`. It also removes a temporary `console.log` statement that was added for debugging.