### PR TITLE
feat: Add currency conversion to AI Evaluation plugin

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -233,6 +233,12 @@ A new section in Admin Tools allows you to monitor LLM usage in detail:
     *   New file defining API endpoints for tracking AI usage:
         *   `POST /api/v1/ai_usage/record`: Records token usage. Called internally by `/api/v1/ai_eval`.
         *   `GET /api/v1/ai_usage/monthly_summary`: Retrieves aggregated monthly usage data.
+    *   **Currency Conversion:** This file also contains the logic for fetching and caching exchange rates from `exchangerate.host`.
+        *   It uses the `axios` library to make API calls to `https://api.exchangerate.host/latest`.
+        *   The API key is passed as a query parameter `access_key`.
+        *   The fetched exchange rates are stored in a new MongoDB collection named `exchange_rates`.
+        *   The logic respects the `AI_LLM_EXCHANGERATE_API_POLING_INTERVALL` and `AI_LLM_EXCHANGERATE_API_LIMIT` settings.
+        *   The official documentation for the API can be found at [https://exchangerate.host/documentation](https://exchangerate.host/documentation).
 *   **`lib/api/index.js`:**
     *   Registered the `/ai_settings` and `/ai_usage` API routers.
     *   Modified the `/api/v1/ai_eval` (POST) endpoint (likely located within `lib/api/index.js`):


### PR DESCRIPTION
This commit introduces a new feature to the AI Evaluation plugin that allows for the conversion of costs from USD to another currency.

The following changes have been made:
- Four new settings have been added to `lib/settings.js` to configure the currency conversion feature: `AI_LLM_EXCHANGERATE_API_KEY`, `AI_LLM_EXCHANGERATE_API_CURRENCY`, `AI_LLM_EXCHANGERATE_API_LIMIT`, and `AI_LLM_EXCHANGERATE_API_POLING_INTERVALL`.
- The backend API in `lib/api/ai_usage_api.js` has been updated to fetch exchange rates from `exchangerate.host`, cache them in a new `exchange_rates` collection in MongoDB, and convert the costs in the monthly summary.
- The frontend in `lib/admin_plugins/ai_usage_viewer.js` has been updated to display the converted costs in the AI Usage Statistics table.
- The documentation in `ai_evaluation.md` has been updated to reflect the new feature.