### PR TITLE
feat: Add currency conversion to AI Evaluation plugin

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -54,6 +54,16 @@ The following environment variables must be set on your Nightscout server. After
 *   `AI_LLM_1K_TOKEN_COSTS_OUTPUT` (Optional)
     *   **Description:** The cost for 1000 output tokens.
     *   *Default:* `0.015`
+*   `AI_LLM_EXCHANGERATE_API_KEY` (Optional)
+    *   **Description:** Your API key for exchangerate.host. This is required to enable currency conversion.
+*   `AI_LLM_EXCHANGERATE_API_CURRENCY` (Optional)
+    *   **Description:** The target currency to convert costs to (e.g., `EUR`, `GBP`). If this is set, the plugin will attempt to fetch exchange rates.
+*   `AI_LLM_EXCHANGERATE_API_LIMIT` (Optional)
+    *   **Description:** The maximum number of API requests to make to the exchange rate service per month.
+    *   *Default:* `100`
+*   `AI_LLM_EXCHANGERATE_API_POLING_INTERVALL` (Optional)
+    *   **Description:** The number of days to wait before fetching a new exchange rate.
+    *   *Default:* `7`
 
 #### b. Admin UI for Prompts (Recommended)
 
@@ -104,6 +114,7 @@ A new section in Admin Tools allows you to monitor LLM usage in detail:
         *   **Total:** The total costs for the month.
         *   **Avg/Req:** The average costs per request.
         *   **Avg/Day:** The average costs per day requested.
+    *   **Currency Conversion:** If `AI_LLM_EXCHANGERATE_API_CURRENCY` is set, the table will also display the costs converted to the specified currency. A note will appear below the table indicating that conversion is active.
 4.  This detailed data helps monitor the cost and efficiency of LLM interactions.
 
 ### 2. Generating an AI Evaluation

--- a/lib/admin_plugins/ai_usage_viewer.js
+++ b/lib/admin_plugins/ai_usage_viewer.js
@@ -9,10 +9,16 @@ function init(ctx) {
         const $ = window.jQuery;
         const monthlyData = data.monthly || [];
         const totalData = data.total || {};
+        const exchangeRateInfo = data.exchangeRateInfo;
 
         if (monthlyData.length === 0) {
             $(placeholderId).html(`<p>${client.translate('No AI usage data available yet.')}</p>`);
             return;
+        }
+
+        let costHeaders = `<th colspan="3">${client.translate('Costs (USD)')}</th>`;
+        if (exchangeRateInfo) {
+            costHeaders += `<th colspan="3">${client.translate('Costs')} (${exchangeRateInfo.currency})</th>`;
         }
 
         let tableHtml = `
@@ -26,7 +32,7 @@ function init(ctx) {
             <th colspan="3">${client.translate('Total Tokens')}</th>
             <th colspan="3">${client.translate('Avg Tokens/Req')}</th>
             <th colspan="3">${client.translate('Avg Tokens/Day')}</th>
-            <th colspan="3">${client.translate('Costs')}</th>
+            ${costHeaders}
           </tr>
           <tr>
             <th>${client.translate('Input')}</th>
@@ -41,12 +47,31 @@ function init(ctx) {
             <th>${client.translate('Total')}</th>
             <th>${client.translate('Avg/Req')}</th>
             <th>${client.translate('Avg/Day')}</th>
+            ${exchangeRateInfo ? `
+            <th>${client.translate('Total')}</th>
+            <th>${client.translate('Avg/Req')}</th>
+            <th>${client.translate('Avg/Day')}</th>
+            ` : ''}
           </tr>
         </thead>
         <tbody>
     `;
 
         monthlyData.forEach(function (monthEntry) {
+            let costCells = `
+          <td>$${parseFloat(monthEntry.total_costs || 0).toFixed(4)}</td>
+          <td>$${parseFloat(monthEntry.avg_costs_per_request || 0).toFixed(4)}</td>
+          <td>$${parseFloat(monthEntry.avg_costs_per_day_requested || 0).toFixed(4)}</td>
+      `;
+            if (exchangeRateInfo) {
+                const currency = exchangeRateInfo.currency.toLowerCase();
+                costCells += `
+            <td>${parseFloat(monthEntry['total_costs_' + currency] || 0).toFixed(4)}</td>
+            <td>${parseFloat(monthEntry['avg_costs_per_request_' + currency] || 0).toFixed(4)}</td>
+            <td>${parseFloat(monthEntry['avg_costs_per_day_requested_' + currency] || 0).toFixed(4)}</td>
+        `;
+            }
+
             tableHtml += `
         <tr>
           <td>${monthEntry.month}</td>
@@ -66,12 +91,25 @@ function init(ctx) {
           <td>${parseFloat(monthEntry.avg_completion_tokens_per_day).toFixed(0)}</td>
           <td>${parseFloat(monthEntry.avg_tokens_per_day).toFixed(0)}</td>
 
-          <td>$${parseFloat(monthEntry.total_costs || 0).toFixed(4)}</td>
-          <td>$${parseFloat(monthEntry.avg_costs_per_request || 0).toFixed(4)}</td>
-          <td>$${parseFloat(monthEntry.avg_costs_per_day_requested || 0).toFixed(4)}</td>
+          ${costCells}
         </tr>
       `;
         });
+
+        let totalCostCells = `
+            <td>$${parseFloat(totalData.total_costs || 0).toFixed(4)}</td>
+            <td>$${parseFloat(totalData.avg_costs_per_request || 0).toFixed(4)}</td>
+            <td>$${parseFloat(totalData.avg_costs_per_day_requested || 0).toFixed(4)}</td>
+      `;
+
+        if (exchangeRateInfo) {
+            const currency = exchangeRateInfo.currency.toLowerCase();
+            totalCostCells += `
+            <td>${parseFloat(totalData['total_costs_' + currency] || 0).toFixed(4)}</td>
+            <td>${parseFloat(totalData['avg_costs_per_request_' + currency] || 0).toFixed(4)}</td>
+            <td>${parseFloat(totalData['avg_costs_per_day_requested_' + currency] || 0).toFixed(4)}</td>
+        `;
+        }
 
         tableHtml += `
         </tbody>
@@ -94,13 +132,18 @@ function init(ctx) {
             <td>${parseFloat(totalData.avg_completion_tokens_per_day || 0).toFixed(0)}</td>
             <td>${parseFloat(totalData.avg_tokens_per_day || 0).toFixed(0)}</td>
 
-            <td>$${parseFloat(totalData.total_costs || 0).toFixed(4)}</td>
-            <td>$${parseFloat(totalData.avg_costs_per_request || 0).toFixed(4)}</td>
-            <td>$${parseFloat(totalData.avg_costs_per_day_requested || 0).toFixed(4)}</td>
+            ${totalCostCells}
           </tr>
         </tfoot>
       </table>
       <p><em>${client.translate('Note: Token counts are based on information returned by the LLM API.')}</em></p>
+      `;
+
+        if (exchangeRateInfo) {
+            tableHtml += `<p><em>${client.translate('Currency conversion is activated via AI_LLM_EXCHANGERATE_API_CURRENCY - make sure AI_LLM_EXCHANGERATE_API_KEY is set. Exchange rate (USD to %s): %s', [exchangeRateInfo.currency, exchangeRateInfo.rate.toFixed(4)])}</em></p>`;
+        }
+
+        tableHtml += `
       <style>
          .table-ai-usage {
            margin: 20px 0;

--- a/lib/api/ai_usage_api.js
+++ b/lib/api/ai_usage_api.js
@@ -1,6 +1,79 @@
 'use strict';
 
+const axios = require('axios');
 const USAGE_COLLECTION_NAME = 'ai_usage_stats';
+const EXCHANGE_RATES_COLLECTION_NAME = 'exchange_rates';
+
+async function getExchangeRate(ctx) {
+  const targetCurrency = ctx.settings.ai_llm_exchangerate_api_currency;
+  if (!targetCurrency) {
+    return null;
+  }
+
+  const exchangeRatesCollection = ctx.store.collection(EXCHANGE_RATES_COLLECTION_NAME);
+  const apiKey = ctx.settings.ai_llm_exchangerate_api_key;
+  const pollingIntervalDays = ctx.settings.ai_llm_exchangerate_api_poling_intervall || 7;
+  const monthlyLimit = ctx.settings.ai_llm_exchangerate_api_limit || 100;
+
+  const lastRate = await exchangeRatesCollection.findOne({}, { sort: { last_fetched: -1 } });
+
+  const now = new Date();
+  const oneDay = 24 * 60 * 60 * 1000;
+  let needsFetch = true;
+  let usageCount = 0;
+  let lastFetchMonth = -1;
+
+  if (lastRate) {
+    const lastFetchDate = new Date(lastRate.last_fetched);
+    lastFetchMonth = lastFetchDate.getUTCMonth();
+    const diffDays = Math.round(Math.abs((now - lastFetchDate) / oneDay));
+    if (diffDays < pollingIntervalDays) {
+      needsFetch = false;
+    }
+    usageCount = lastRate.monthly_usage_count || 0;
+  }
+
+  const currentMonth = now.getUTCMonth();
+  if (lastFetchMonth !== currentMonth) {
+    usageCount = 0; // Reset monthly usage count
+  }
+
+  if (needsFetch && usageCount < monthlyLimit) {
+    try {
+      const response = await axios.get(`https://api.exchangerate.host/latest`, {
+        params: {
+          base: 'USD',
+          symbols: targetCurrency,
+          access_key: apiKey
+        }
+      });
+
+      if (response.data && response.data.success) {
+        const rate = response.data.rates[targetCurrency];
+        if (rate) {
+          const newRateRecord = {
+            base_currency: 'USD',
+            target_currency: targetCurrency,
+            rate: rate,
+            last_fetched: now,
+            monthly_usage_count: usageCount + 1
+          };
+          await exchangeRatesCollection.insertOne(newRateRecord);
+          return { rate, currency: targetCurrency };
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching exchange rate:', error.message);
+      // Fallback to last known rate if API fails
+    }
+  }
+
+  if (lastRate) {
+    return { rate: lastRate.rate, currency: lastRate.target_currency };
+  }
+
+  return null;
+}
 
 // This function will be called from lib/api/index.js to set up the routes
 function configure(app, wares, ctx) {
@@ -55,11 +128,12 @@ function configure(app, wares, ctx) {
   api.get('/monthly_summary', ctx.authorization.isPermitted('api:treatments:read'), async (req, res) => {
     try {
       const usageCollection = ctx.store.collection(USAGE_COLLECTION_NAME);
+      const exchangeRateInfo = await getExchangeRate(ctx);
 
       const cost_input = ctx.settings.ai_llm_1k_token_costs_input;
       const cost_output = ctx.settings.ai_llm_1k_token_costs_output;
 
-      const monthlyPipeline = [
+      let monthlyPipeline = [
         {
           $project: {
             month: { $dateToString: { format: "%Y-%m", date: "$createdAt" } },
@@ -120,7 +194,17 @@ function configure(app, wares, ctx) {
         }
       ];
 
-      const totalPipeline = [
+      if (exchangeRateInfo) {
+        monthlyPipeline.push({
+          $addFields: {
+            [`total_costs_${exchangeRateInfo.currency.toLowerCase()}`]: { $multiply: ["$total_costs", exchangeRateInfo.rate] },
+            [`avg_costs_per_request_${exchangeRateInfo.currency.toLowerCase()}`]: { $multiply: ["$avg_costs_per_request", exchangeRateInfo.rate] },
+            [`avg_costs_per_day_requested_${exchangeRateInfo.currency.toLowerCase()}`]: { $multiply: ["$avg_costs_per_day_requested", exchangeRateInfo.rate] }
+          }
+        });
+      }
+
+      let totalPipeline = [
         {
           $group: {
             _id: "all_time",
@@ -167,12 +251,23 @@ function configure(app, wares, ctx) {
         }
       ];
 
+      if (exchangeRateInfo) {
+        totalPipeline.push({
+          $addFields: {
+            [`total_costs_${exchangeRateInfo.currency.toLowerCase()}`]: { $multiply: ["$total_costs", exchangeRateInfo.rate] },
+            [`avg_costs_per_request_${exchangeRateInfo.currency.toLowerCase()}`]: { $multiply: ["$avg_costs_per_request", exchangeRateInfo.rate] },
+            [`avg_costs_per_day_requested_${exchangeRateInfo.currency.toLowerCase()}`]: { $multiply: ["$avg_costs_per_day_requested", exchangeRateInfo.rate] }
+          }
+        });
+      }
+
       const monthlyData = await usageCollection.aggregate(monthlyPipeline).toArray();
       const totalData = await usageCollection.aggregate(totalPipeline).toArray();
 
       res.json({
         monthly: monthlyData,
-        total: totalData[0] || {}
+        total: totalData[0] || {},
+        exchangeRateInfo: exchangeRateInfo
       });
 
     } catch (error) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -83,6 +83,11 @@ function init () {
     , ai_llm_key_is_set: false // Default for the new flag, will be updated based on ai_llm_key
     , ai_llm_1k_token_costs_input: 0.005 // Default costs for 1k input tokens
     , ai_llm_1k_token_costs_output: 0.015 // Default costs for 1k output tokens
+    // Exchange Rate API Settings
+    , ai_llm_exchangerate_api_key: '' // API Key for exchangerate.host
+    , ai_llm_exchangerate_api_currency: '' // Target currency for conversion
+    , ai_llm_exchangerate_api_limit: 100 // Monthly API request limit
+    , ai_llm_exchangerate_api_poling_intervall: 7 // Days between API calls
   };
 
   if(settings.ai_llm_debug === true) {
@@ -99,6 +104,7 @@ function init () {
     , 'obscured'
     , 'obscureDeviceProvenance'
     , 'ai_llm_key' // Added AI LLM Key
+    , 'ai_llm_exchangerate_api_key'
   ];
 
   var valueMappers = {
@@ -135,6 +141,8 @@ function init () {
     , ai_llm_key_is_set: mapTruthy // Added mapper for ai_llm_key_is_set
     , ai_llm_1k_token_costs_input: mapNumber
     , ai_llm_1k_token_costs_output: mapNumber
+    , ai_llm_exchangerate_api_limit: mapNumber
+    , ai_llm_exchangerate_api_poling_intervall: mapNumber
   };
 
   function filterObj(obj, secureKeys) {


### PR DESCRIPTION
I've introduced a new feature to the AI Evaluation plugin that allows for the conversion of costs from USD to another currency.

Here are the changes I made:
- I added four new settings to `lib/settings.js` to configure the currency conversion feature: `AI_LLM_EXCHANGERATE_API_KEY`, `AI_LLM_EXCHANGERATE_API_CURRENCY`, `AI_LLM_EXCHANGERATE_API_LIMIT`, and `AI_LLM_EXCHANGERATE_API_POLING_INTERVALL`.
- I updated the backend API in `lib/api/ai_usage_api.js` to fetch exchange rates from `exchangerate.host`, cache them in a new `exchange_rates` collection in MongoDB, and convert the costs in the monthly summary.
- I updated the frontend in `lib/admin_plugins/ai_usage_viewer.js` to display the converted costs in the AI Usage Statistics table.
- I updated the documentation in `ai_evaluation.md` to reflect the new feature.