### PR TITLE
fix: Display warning when currency conversion fails

### DIFF
--- a/lib/admin_plugins/ai_usage_viewer.js
+++ b/lib/admin_plugins/ai_usage_viewer.js
@@ -141,6 +141,8 @@ function init(ctx) {
 
         if (exchangeRateInfo) {
             tableHtml += `<p><em>${client.translate('Currency conversion is activated via AI_LLM_EXCHANGERATE_API_CURRENCY - make sure AI_LLM_EXCHANGERATE_API_KEY is set. Exchange rate (USD to %s): %s', [exchangeRateInfo.currency, exchangeRateInfo.rate.toFixed(4)])}</em></p>`;
+        } else if (client.settings.ai_llm_exchangerate_api_currency) {
+            tableHtml += `<p><em>${client.translate('Currency conversion is enabled via AI_LLM_EXCHANGERATE_API_CURRENCY, but it seems there is no result from that endpoint. Check if AI_LLM_EXCHANGERATE_API_KEY is set.')}</em></p>`;
         }
 
         tableHtml += `


### PR DESCRIPTION
This commit addresses your feedback.

When `AI_LLM_EXCHANGERATE_API_CURRENCY` is set, but the API call to `exchangerate.host` fails (e.g. due to a missing `AI_LLM_EXCHANGERATE_API_KEY`), the frontend will now display a warning message to you, guiding you on how to fix the issue.

This improves your experience by providing clear feedback when the currency conversion feature is not working as expected.