### PR TITLE
refactor: Use request library for API calls

### DIFF
--- a/lib/api/ai_usage_api.js
+++ b/lib/api/ai_usage_api.js
@@ -1,78 +1,86 @@
 'use strict';
 
-const axios = require('axios');
+const request = require('request');
 const USAGE_COLLECTION_NAME = 'ai_usage_stats';
 const EXCHANGE_RATES_COLLECTION_NAME = 'exchange_rates';
 
-async function getExchangeRate(ctx) {
-  const targetCurrency = ctx.settings.ai_llm_exchangerate_api_currency;
-  if (!targetCurrency) {
-    return null;
-  }
-
-  const exchangeRatesCollection = ctx.store.collection(EXCHANGE_RATES_COLLECTION_NAME);
-  const apiKey = ctx.settings.ai_llm_exchangerate_api_key;
-  const pollingIntervalDays = ctx.settings.ai_llm_exchangerate_api_poling_intervall || 7;
-  const monthlyLimit = ctx.settings.ai_llm_exchangerate_api_limit || 100;
-
-  const lastRate = await exchangeRatesCollection.findOne({}, { sort: { last_fetched: -1 } });
-
-  const now = new Date();
-  const oneDay = 24 * 60 * 60 * 1000;
-  let needsFetch = true;
-  let usageCount = 0;
-  let lastFetchMonth = -1;
-
-  if (lastRate) {
-    const lastFetchDate = new Date(lastRate.last_fetched);
-    lastFetchMonth = lastFetchDate.getUTCMonth();
-    const diffDays = Math.round(Math.abs((now - lastFetchDate) / oneDay));
-    if (diffDays < pollingIntervalDays) {
-      needsFetch = false;
+function getExchangeRate(ctx) {
+  return new Promise(async (resolve, reject) => {
+    const targetCurrency = ctx.settings.ai_llm_exchangerate_api_currency;
+    if (!targetCurrency) {
+      return resolve(null);
     }
-    usageCount = lastRate.monthly_usage_count || 0;
-  }
 
-  const currentMonth = now.getUTCMonth();
-  if (lastFetchMonth !== currentMonth) {
-    usageCount = 0; // Reset monthly usage count
-  }
+    const exchangeRatesCollection = ctx.store.collection(EXCHANGE_RATES_COLLECTION_NAME);
+    const apiKey = ctx.settings.ai_llm_exchangerate_api_key;
+    const pollingIntervalDays = ctx.settings.ai_llm_exchangerate_api_poling_intervall || 7;
+    const monthlyLimit = ctx.settings.ai_llm_exchangerate_api_limit || 100;
 
-  if (needsFetch && usageCount < monthlyLimit) {
-    try {
-      const response = await axios.get(`https://api.exchangerate.host/latest`, {
-        params: {
+    const lastRate = await exchangeRatesCollection.findOne({}, { sort: { last_fetched: -1 } });
+
+    const now = new Date();
+    const oneDay = 24 * 60 * 60 * 1000;
+    let needsFetch = true;
+    let usageCount = 0;
+    let lastFetchMonth = -1;
+
+    if (lastRate) {
+      const lastFetchDate = new Date(lastRate.last_fetched);
+      lastFetchMonth = lastFetchDate.getUTCMonth();
+      const diffDays = Math.round(Math.abs((now - lastFetchDate) / oneDay));
+      if (diffDays < pollingIntervalDays) {
+        needsFetch = false;
+      }
+      usageCount = lastRate.monthly_usage_count || 0;
+    }
+
+    const currentMonth = now.getUTCMonth();
+    if (lastFetchMonth !== currentMonth) {
+      usageCount = 0; // Reset monthly usage count
+    }
+
+    if (needsFetch && usageCount < monthlyLimit) {
+      const requestOptions = {
+        uri: 'https://api.exchangerate.host/latest',
+        method: 'GET',
+        qs: {
           base: 'USD',
           symbols: targetCurrency,
           access_key: apiKey
+        },
+        json: true
+      };
+
+      request(requestOptions, async (error, response, body) => {
+        if (error) {
+          console.error('Error fetching exchange rate:', error.message);
+          if (lastRate) return resolve({ rate: lastRate.rate, currency: lastRate.target_currency });
+          return resolve(null);
         }
+
+        if (body && body.success) {
+          const rate = body.rates[targetCurrency];
+          if (rate) {
+            const newRateRecord = {
+              base_currency: 'USD',
+              target_currency: targetCurrency,
+              rate: rate,
+              last_fetched: now,
+              monthly_usage_count: usageCount + 1
+            };
+            await exchangeRatesCollection.insertOne(newRateRecord);
+            return resolve({ rate, currency: targetCurrency });
+          }
+        }
+
+        if (lastRate) return resolve({ rate: lastRate.rate, currency: lastRate.target_currency });
+        resolve(null);
       });
-
-      if (response.data && response.data.success) {
-        const rate = response.data.rates[targetCurrency];
-        if (rate) {
-          const newRateRecord = {
-            base_currency: 'USD',
-            target_currency: targetCurrency,
-            rate: rate,
-            last_fetched: now,
-            monthly_usage_count: usageCount + 1
-          };
-          await exchangeRatesCollection.insertOne(newRateRecord);
-          return { rate, currency: targetCurrency };
-        }
-      }
-    } catch (error) {
-      console.error('Error fetching exchange rate:', error.message);
-      // Fallback to last known rate if API fails
+    } else {
+      if (lastRate) return resolve({ rate: lastRate.rate, currency: lastRate.target_currency });
+      resolve(null);
     }
-  }
-
-  if (lastRate) {
-    return { rate: lastRate.rate, currency: lastRate.target_currency };
-  }
-
-  return null;
+  });
 }
 
 // This function will be called from lib/api/index.js to set up the routes


### PR DESCRIPTION
I've refactored the `getExchangeRate` function in `lib/api/ai_usage_api.js` to use the `request` library instead of `axios`. This change aligns the code with the existing pattern for making external API calls in the Nightscout application.

This change is in response to your feedback that the previous implementation was not working as expected and was not following the established coding patterns of the project.