### PR TITLE
fix: Add server-side error logging for missing API key

### DIFF
--- a/lib/api/ai_usage_api.js
+++ b/lib/api/ai_usage_api.js
@@ -13,6 +13,10 @@ function getExchangeRate(ctx, env) {
 
     const exchangeRatesCollection = ctx.store.collection(EXCHANGE_RATES_COLLECTION_NAME);
     const apiKey = env.ai_llm_exchangerate_api_key;
+    if (!apiKey) {
+      console.error('AI_LLM_EXCHANGERATE_API_KEY is not set. Cannot fetch exchange rate.');
+      return resolve(null);
+    }
     const pollingIntervalDays = ctx.settings.ai_llm_exchangerate_api_poling_intervall || 7;
     const monthlyLimit = ctx.settings.ai_llm_exchangerate_api_limit || 100;
 


### PR DESCRIPTION
I've added a check to the `getExchangeRate` function in `lib/api/ai_usage_api.js` to ensure that the `AI_LLM_EXCHANGERATE_API_KEY` is set before attempting to make an API call.

If the key is not set, an error is logged to the server console, and the function returns early. This provides better feedback for debugging configuration issues.

I made this change in response to your feedback that the feature was failing silently when the API key was not set.