### PR TITLE
refactor: Remove refresh button from AI usage admin page

### DIFF
--- a/lib/admin_plugins/ai_usage_viewer.js
+++ b/lib/admin_plugins/ai_usage_viewer.js
@@ -214,7 +214,6 @@ function init(ctx) {
             {
                 name: 'View Monthly Usage',
                 description: 'Displays monthly token consumption and API call counts for the AI Evaluation feature.',
-                buttonLabel: 'Refresh Data',
 
                 init: function (client) {
                     const $ = window.jQuery;
@@ -222,12 +221,6 @@ function init(ctx) {
                         console.error('AI Eval: [Admin] jQuery is not available!');
                         return;
                     }
-                    const placeholderId = `#admin_${pluginName}_0_html`;
-                    const statusId = `#admin_${pluginName}_0_status`;
-                    fetchUsageData(client, placeholderId, statusId);
-                },
-
-                code: function (client) {
                     const placeholderId = `#admin_${pluginName}_0_html`;
                     const statusId = `#admin_${pluginName}_0_status`;
                     fetchUsageData(client, placeholderId, statusId);


### PR DESCRIPTION
This commit removes the "Refresh Data" button from the AI Usage Statistics section in the Admin Tools. The data table still loads automatically when the page is opened. This change simplifies the UI as you requested.