### PR TITLE
fix: Use monthly summary for AI spending limit check

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -19,6 +19,10 @@ This document serves as both a user manual and technical documentation for the p
 *   **Secure API Key Handling:** The LLM API key is stored as a server-side environment variable and is not exposed to the client.
 *   **Token Usage Tracking:** Automatically tracks the number of tokens consumed and API calls made to the LLM, viewable in Admin Tools.
 
+## Bug Fixes
+
+*   **Monthly Spending Limit Check:** The check for the `AI_LLM_MONTHLY_USD_LIMIT` was previously using an inefficient method of calculating the current month's spending. This has been fixed to use the pre-calculated monthly summary, which is faster and more reliable. This ensures that the "Send to AI" button is correctly disabled and a warning is shown when the monthly spending limit is reached.
+
 ## User Guide
 
 ### 1. Configuration

--- a/lib/api/ai_usage_api.js
+++ b/lib/api/ai_usage_api.js
@@ -182,42 +182,24 @@ function configure(app, wares, ctx, env) {
 
   api.get('/check_limit', ctx.authorization.isPermitted('api:treatments:read'), async (req, res) => {
     try {
-      const usageCollection = ctx.store.collection(USAGE_COLLECTION_NAME);
-      const monthlyLimit = env.ai_llm_monthly_usd_limit;
+      const summaryCollection = ctx.store.collection(SUMMARY_COLLECTION_NAME);
+      const monthlyLimit = parseFloat(env.ai_llm_monthly_usd_limit);
+
+      if (isNaN(monthlyLimit) || monthlyLimit <= 0) {
+        // If the limit is not set or invalid, there's nothing to check.
+        return res.json({
+          limitExceeded: false,
+          currentCost: 0,
+          limit: null
+        });
+      }
 
       const now = new Date();
       const currentMonthStr = now.toISOString().substring(0, 7); // "YYYY-MM"
 
-      const cost_input = ctx.settings.ai_llm_1k_token_costs_input;
-      const cost_output = ctx.settings.ai_llm_1k_token_costs_output;
+      const monthSummary = await summaryCollection.findOne({ _id: currentMonthStr });
 
-      const pipeline = [
-        {
-          $match: {
-            createdAt: { $gte: new Date(currentMonthStr + "-01") }
-          }
-        },
-        {
-          $group: {
-            _id: null,
-            total_prompt_tokens: { $sum: "$prompt_tokens_used" },
-            total_completion_tokens: { $sum: "$completion_tokens_used" }
-          }
-        },
-        {
-          $addFields: {
-            total_costs: {
-              $add: [
-                { $multiply: [{ $divide: ["$total_prompt_tokens", 1000] }, cost_input] },
-                { $multiply: [{ $divide: ["$total_completion_tokens", 1000] }, cost_output] }
-              ]
-            }
-          }
-        }
-      ];
-
-      const result = await usageCollection.aggregate(pipeline).toArray();
-      const currentCost = result.length > 0 ? result[0].total_costs : 0;
+      const currentCost = monthSummary ? monthSummary.total_costs : 0;
       const limitExceeded = currentCost >= monthlyLimit;
 
       res.json({


### PR DESCRIPTION
The /api/v1/ai_usage/check_limit endpoint was calculating the current month's spending by aggregating raw usage stats on every call. This was inefficient and inconsistent with the introduction of the `ai_usage_summary` collection.

This commit refactors the endpoint to read the `total_costs` directly from the pre-calculated monthly document in the `ai_usage_summary` collection. This makes the check faster and more reliable.

The `ai_evaluation.md` documentation has been updated to include a note about this bug fix.