### PR TITLE
feat: Display current month's cost on AI evaluation tab

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -139,7 +139,10 @@ A new section in Admin Tools allows you to monitor LLM usage in detail:
     *   Once the main report data (from step 2) is loaded and all AI settings are confirmed to be correct, the AI evaluation will **automatically begin**. There is no separate "Show AI Evaluation" button to click in this tab.
     *   The system will display "Loading AI evaluation..." while it processes the data and communicates with the LLM.
     *   The LLM's response will then be displayed in the main content area of the tab.
-    *   **Estimated Cost:** Below the "Send to AI" button, a message will appear showing the estimated cost for the selected number of days, based on your historical usage statistics. If currency conversion is enabled, the converted amount will also be shown.
+    *   **Cost Information:** Below the "Send to AI" button, two lines of cost information will appear:
+        *   **Estimated Cost:** Shows the estimated cost for the selected number of days, based on your historical usage statistics.
+        *   **Costs for current month:** Shows the total accumulated cost for the current calendar month.
+    *   If currency conversion is enabled, the converted amounts will also be shown for both lines.
 
 ### 3. Understanding the Output
 

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -919,23 +919,45 @@ function init(ctx) {
                                 window.cgmData = cgmData;
                             }
 
-                            // Display estimated cost
+                            // Display estimated cost and current month's cost
                             $.ajax({
                                 url: baseUrl + '/api/v1/ai_usage/monthly_summary',
                                 type: 'GET',
                                 headers: headers,
                                 success: function (summaryData) {
+                                    let costHtml = '';
                                     const totalStats = summaryData.total;
+                                    const exchangeRateInfo = summaryData.exchangeRateInfo;
+
+                                    // Estimated cost for the current selection
                                     if (totalStats && totalStats.avg_costs_per_day_requested > 0) {
                                         const numberOfDays = window.cgmData.days.length;
                                         const estimatedCost = numberOfDays * totalStats.avg_costs_per_day_requested;
-                                        let costHtml = `Estimated costs for the ${numberOfDays} days based on the usage statistics: $${estimatedCost.toFixed(4)}`;
+                                        costHtml += `Estimated costs for the ${numberOfDays} days based on the usage statistics: $${estimatedCost.toFixed(4)}`;
 
-                                        const exchangeRateInfo = summaryData.exchangeRateInfo;
                                         if (exchangeRateInfo && exchangeRateInfo.rate) {
                                             const convertedCost = estimatedCost * exchangeRateInfo.rate;
                                             costHtml += ` (${convertedCost.toFixed(4)} ${exchangeRateInfo.currency})`;
                                         }
+                                    }
+
+                                    // Current month's total cost
+                                    const now = new Date();
+                                    const currentMonthStr = now.toISOString().substring(0, 7); // "YYYY-MM"
+                                    const currentMonthData = summaryData.monthly.find(m => m._id === currentMonthStr);
+
+                                    if (currentMonthData) {
+                                        if (costHtml) {
+                                            costHtml += '<br>'; // Add a line break if there's already content
+                                        }
+                                        costHtml += `Costs for current month: $${currentMonthData.total_costs.toFixed(4)}`;
+                                        if (exchangeRateInfo && exchangeRateInfo.rate) {
+                                            const convertedCost = currentMonthData.total_costs * exchangeRateInfo.rate;
+                                            costHtml += ` / ${convertedCost.toFixed(4)} ${exchangeRateInfo.currency}`;
+                                        }
+                                    }
+
+                                    if (costHtml) {
                                         $('#aiEstimatedCost').html(costHtml);
                                     }
                                 },


### PR DESCRIPTION
This commit enhances the AI Evaluation tab to display the total accumulated cost for the current calendar month.

The cost is shown below the estimated cost for the selected period and includes the converted currency if currency conversion is enabled.

The `ai_evaluation.md` documentation has been updated to reflect this new feature.