### PR TITLE
refactor: Adjust formatting of AI statistics display

### DIFF
--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -397,9 +397,9 @@ function init(ctx) {
                                 }
 
                                 const statsHtml = `
-                                    <p><strong>AI Usage Statistics</strong></p>
-                                    <p>for ${window.aiResponsesDataObject.date_from} - ${window.aiResponsesDataObject.date_till} (${window.aiResponsesDataObject.interim_calls_amount} days)</p>
-                                    <p>Total API Calls: ${window.aiResponsesDataObject.total_calls} (Interim: ${window.aiResponsesDataObject.interim_calls_amount}, Final: 1)</p>
+                                    <p><strong>AI Usage Statistics</strong><br>
+                                    for ${window.aiResponsesDataObject.date_from} - ${window.aiResponsesDataObject.date_till} (${window.aiResponsesDataObject.interim_calls_amount} days)<br>
+                                    Total API Calls: ${window.aiResponsesDataObject.total_calls} (Interim: ${window.aiResponsesDataObject.interim_calls_amount}, Final: 1)</p>
                                     <p><strong>Overall Session Usage:</strong></p>
                                     <ul>
                                         <li>Prompt Tokens: ${window.aiResponsesDataObject.prompt_tokens_used} ${calculateAndFormatCost(window.aiResponsesDataObject.prompt_tokens_used, costInput, exchangeRateInfo)}</li>
@@ -1283,8 +1283,7 @@ function init(ctx) {
         max-height: 300px;
         overflow-y: auto;
       }
-      #aiStatistics
-      {
+      #aiStatistics {
         background-color: #e0e0e0; /* Slightly different background for distinction */
         border: 1px solid #ccc;
         padding: 10px;
@@ -1296,6 +1295,15 @@ function init(ctx) {
         max-height: 300px;
         overflow-y: auto;
         max-width: 400px;
+      }
+      #aiStatistics p {
+        margin: 0;
+      }
+      #aiStatistics ul {
+        margin-top: -20px;
+      }
+      #aiStatistics li {
+        margin-top: -15px;
       }
     `,
 


### PR DESCRIPTION
This commit applies specific formatting adjustments to the AI statistics box on the evaluation tab, as you requested.

- The HTML structure for the statistics header has been compacted into a single paragraph with line breaks.
- Custom CSS rules have been added to fine-tune the margins within the statistics box for a more compact appearance.