### PR TITLE
fix: Correct AI evaluation rendering, layout, and stats bugs

### DIFF
--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -86,6 +86,291 @@ function init(ctx) {
             responseDebugArea.style.display = 'none';
         }
 
+        /**
+         * Unified CGM Report Renderer
+         * - Auto-detects Daily vs Multi-Day schema
+         * - Plain JS, framework-agnostic
+         * - Renders accessible HTML with headings, lists, and tables
+         */
+
+        function renderCgmReport(data, mount) {
+            const el = typeof mount === 'string' ? document.querySelector(mount) : mount;
+            if (!el) throw new Error('Mount element not found');
+
+            const isMultiDay = !!data.period; // final schema has "period"
+            el.innerHTML = isMultiDay ? renderMultiDay(data) : renderDaily(data);
+        }
+
+        /* ---------- Utilities ---------- */
+
+        const fmt = (val, unit = '', decimals = 1) =>
+            val === null || val === undefined || Number.isNaN(val)
+                ? '-'
+                : `${Number(val).toFixed(decimals)}${unit}`;
+
+        const list = (items = []) =>
+            `<ul>${(items || []).map((x) => `<li>${escapeHtml(x)}</li>`).join('')}</ul>`;
+
+        function escapeHtml(s) {
+            return String(s)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#039;');
+        }
+
+        function table({head, rows}) {
+            return `
+              <table class="cgm-table" role="table">
+                <thead><tr>${head.map((h) => `<th scope="col">${escapeHtml(h)}</th>`).join('')}</tr></thead>
+                <tbody>
+                  ${rows.map((r) => `<tr>${r.map((c) => `<td>${c}</td>`).join('')}</tr>`).join('')}
+                </tbody>
+              </table>`;
+        }
+
+        /* ---------- Daily (Interim) ---------- */
+
+        function renderDaily(d) {
+            const stats = d.statistics || {};
+            const blocks = d.dailyPatterns || {};
+
+            const statsTable = table({
+                head: ['Metric', 'Value'],
+                rows: [
+                    ['Average Glucose', fmt(stats.average_glucose_mgdl, ' mg/dL')],
+                    ['Median Glucose', fmt(stats.median_glucose_mgdl, ' mg/dL')],
+                    ['Standard Deviation', fmt(stats.standard_deviation_mgdl, ' mg/dL')],
+                    ['CV', fmt(stats.cv_percent, ' %')],
+                    ['MAGE', fmt(stats.mage_mgdl, ' mg/dL')],
+                    ['Time in Range', fmt(stats.time_in_range_percent, ' %')],
+                    ['Time Below Range', fmt(stats.time_below_range_percent, ' %')],
+                    ['Time Above Range', fmt(stats.time_above_range_percent, ' %')],
+                    ['Hypo Episodes', escapeHtml(stats.number_of_hypo_episodes ?? '-')],
+                    ['Hyper Episodes', escapeHtml(stats.number_of_hyper_episodes ?? '-')],
+                    ['Longest Hypo', stats.longest_hypo_min != null ? `${stats.longest_hypo_min} min` : '-'],
+                    ['Longest Hyper', stats.longest_hyper_min != null ? `${stats.longest_hyper_min} min` : '-']
+                ]
+            });
+
+            const patternRows = ['00-06', '06-12', '12-18', '18-24'].map((b) => {
+                const v = blocks[b] || {};
+                return [
+                    b,
+                    fmt(v.avg, ' mg/dL'),
+                    fmt(v.sd, ' mg/dL'),
+                    fmt(v.below_pct, ' %'),
+                    fmt(v.in_range_pct, ' %'),
+                    fmt(v.above_pct, ' %')
+                ];
+            });
+
+            const patternsTable = table({
+                head: ['Time Block', 'Avg', 'SD', 'Below %', 'In Range %', 'Above %'],
+                rows: patternRows
+            });
+
+            const anomaliesList = list(
+                (d.anomalies || []).map((a) => {
+                    const base = `${a.type} ${a.start_local}–${a.end_local} (${a.duration_min ?? '-'} min)`;
+                    if (a.type === 'hypoglycemia' && a.nadir_mgdl != null) return `${base}; nadir ${a.nadir_mgdl} mg/dL`;
+                    if (a.type === 'hyperglycemia' && a.peak_mgdl != null) return `${base}; peak ${a.peak_mgdl} mg/dL`;
+                    return base;
+                })
+            );
+
+            return `
+              <style>
+                .cgm-wrap{font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:960px;margin:auto;line-height:1.45}
+                .cgm-wrap h1{font-size:1.6rem;margin:0 0 .5rem}
+                .cgm-wrap h2{font-size:1.2rem;margin:1.2rem 0 .6rem}
+                .cgm-wrap h3{font-size:1rem;margin:1rem 0 .5rem;color:#333}
+                .cgm-table{width:100%;border-collapse:collapse;font-size:.95rem}
+                .cgm-table th,.cgm-table td{border:1px solid #e5e7eb;padding:.5rem .6rem;text-align:left;vertical-align:top}
+                .cgm-table thead th{background:#f8fafc;font-weight:600}
+                ul{padding-left:1.2rem;margin:.2rem 0}
+                .cgm-meta{color:#555;font-size:.9rem}
+                .cgm-grid{display:grid;grid-template-columns:1fr;gap:1rem}
+                @media (min-width:900px){.cgm-grid{grid-template-columns:1fr 1fr}}
+              </style>
+
+              <div class="cgm-wrap">
+                <h1>Daily CGM Report — ${escapeHtml(d.date || '')}</h1>
+                <div class="cgm-grid">
+                  <section>
+                    <h2>Summary</h2>
+                    ${list(d.summary || [])}
+                    <h2>Statistics</h2>
+                    ${statsTable}
+                  </section>
+                  <section>
+                    <h2>Daily Patterns</h2>
+                    ${patternsTable}
+                    <h2>Anomalies</h2>
+                    ${anomaliesList}
+                  </section>
+                </div>
+
+                <section>
+                  <h2>Recommendations</h2>
+                  ${list(d.recommendations || [])}
+                </section>
+
+                <section>
+                  <h2>Data Quality Notes</h2>
+                  ${list(d.data_quality_notes || d.notes || [])}
+                  ${d.meta ? `<p class="cgm-meta">Units: ${escapeHtml(d.meta.units || 'mg/dL')} · Target ${escapeHtml(String(d.meta.target_low_mgdl ?? ''))}–${escapeHtml(String(d.meta.target_high_mgdl ?? ''))} mg/dL</p>` : ''}
+                </section>
+              </div>
+              `;
+        }
+
+        /* ---------- Multi-Day (Final) ---------- */
+
+        function renderMultiDay(d) {
+            const stats = d.overall_statistics || {};
+            const blocks = d.diurnal_patterns || {};
+            const episodes = d.episodes || {};
+
+            const statsTable = table({
+                head: ['Metric', 'Value'],
+                rows: [
+                    ['Average Glucose', fmt(stats.average_glucose_mgdl, ' mg/dL')],
+                    ['Median Glucose', fmt(stats.median_glucose_mgdl, ' mg/dL')],
+                    ['Standard Deviation', fmt(stats.standard_deviation_mgdl, ' mg/dL')],
+                    ['CV', fmt(stats.cv_percent, ' %')],
+                    ['MAGE Overall', fmt(stats.mage_overall_mgdl, ' mg/dL')],
+                    ['Time in Range', fmt(stats.time_in_range_percent, ' %')],
+                    ['Time Below Range', fmt(stats.time_below_range_percent, ' %')],
+                    ['Time Above Range', fmt(stats.time_above_range_percent, ' %')]
+                ]
+            });
+
+            const patternsTable = table({
+                head: ['Time Block', 'Avg', 'SD', 'Below %', 'In Range %', 'Above %'],
+                rows: ['00-06', '06-12', '12-18', '18-24'].map((b) => {
+                    const v = blocks[b] || {};
+                    return [
+                        b,
+                        fmt(v.avg, ' mg/dL'),
+                        fmt(v.sd, ' mg/dL'),
+                        fmt(v.below_pct, ' %'),
+                        fmt(v.in_range_pct, ' %'),
+                        fmt(v.above_pct, ' %')
+                    ];
+                })
+            });
+
+            const epiTable = table({
+                head: ['Type', 'Count', 'Total Minutes', 'Longest (min)', '00–06', '06–12', '12–18', '18–24'],
+                rows: ['hypoglycemia', 'hyperglycemia'].map((t) => {
+                    const e = episodes[t] || {};
+                    const by = (e.by_block || {});
+                    return [
+                        t,
+                        escapeHtml(e.count ?? '-'),
+                        escapeHtml(e.total_minutes ?? '-'),
+                        escapeHtml(e.longest_min ?? '-'),
+                        escapeHtml(by['00-06'] ?? '-'),
+                        escapeHtml(by['06-12'] ?? '-'),
+                        escapeHtml(by['12-18'] ?? '-'),
+                        escapeHtml(by['18-24'] ?? '-')
+                    ];
+                })
+            });
+
+            const perDayTable = table({
+                head: ['Date', 'Avg', 'CV %', 'TIR %', 'TBR %', 'TAR %', 'Hypo Ep.', 'Hyper Ep.', 'Notes'],
+                rows: (d.per_day || []).map((x) => [
+                    escapeHtml(x.date || ''),
+                    fmt(x.average_glucose_mgdl, ' mg/dL'),
+                    fmt(x.cv_percent, ' %'),
+                    fmt(x.tir_percent, ' %'),
+                    fmt(x.tbr_percent, ' %'),
+                    fmt(x.tar_percent, ' %'),
+                    escapeHtml(x.hypo_episodes ?? '-'),
+                    escapeHtml(x.hyper_episodes ?? '-'),
+                    escapeHtml((x.notes || []).join('; '))
+                ])
+            });
+
+            const rec = d.recommendations || {};
+            const recHtml = `
+                <div class="cgm-grid">
+                  <section>
+                    <h3>Therapy Settings</h3>${list(rec.therapy_settings || [])}
+                  </section>
+                  <section>
+                    <h3>Behavioral Timing</h3>${list(rec.behavioral_timing || [])}
+                  </section>
+                  <section>
+                    <h3>Monitoring</h3>${list(rec.monitoring || [])}
+                  </section>
+                </div>
+              `;
+
+            return `
+              <style>
+                .cgm-wrap{font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:1024px;margin:auto;line-height:1.45}
+                .cgm-wrap h1{font-size:1.6rem;margin:0 0 .5rem}
+                .cgm-wrap h2{font-size:1.2rem;margin:1.2rem 0 .6rem}
+                .cgm-wrap h3{font-size:1rem;margin:1rem 0 .5rem;color:#333}
+                .cgm-table{width:100%;border-collapse:collapse;font-size:.95rem}
+                .cgm-table th,.cgm-table td{border:1px solid #e5e7eb;padding:.5rem .6rem;text-align:left;vertical-align:top}
+                .cgm-table thead th{background:#f8fafc;font-weight:600}
+                ul{padding-left:1.2rem;margin:.2rem 0}
+                .cgm-meta{color:#555;font-size:.9rem}
+                .cgm-grid{display:grid;grid-template-columns:1fr;gap:1rem}
+                @media (min-width:900px){.cgm-grid{grid-template-columns:repeat(3,1fr)}}
+              </style>
+
+              <div class="cgm-wrap">
+                <h1>Multi‑Day CGM Report — ${escapeHtml((d.period?.from || '') + ' – ' + (d.period?.to || ''))}</h1>
+                <p class="cgm-meta">${escapeHtml(String(d.period?.days ?? ''))} days total</p>
+
+                <section>
+                  <h2>Summary</h2>
+                  ${list(d.summary || [])}
+                </section>
+
+                <section>
+                  <h2>Overall Statistics</h2>
+                  ${statsTable}
+                </section>
+                <section>
+                  <h2>Diurnal Patterns</h2>
+                  ${patternsTable}
+                </section>
+                <section>
+                  <h2>Episodes</h2>
+                  ${epiTable}
+                </section>
+
+                <section>
+                  <h2>Trends</h2>
+                  ${list((d.trends || []).map(t => `${t.label}: ${t.evidence}`))}
+                </section>
+
+                <section>
+                  <h2>Recommendations</h2>
+                  ${recHtml}
+                </section>
+
+                <section>
+                  <h2>Daily Breakdown</h2>
+                  ${perDayTable}
+                </section>
+
+                <section>
+                  <h2>Data Quality Notes</h2>
+                  ${list(d.data_quality_notes || [])}
+                  ${d.meta ? `<p class="cgm-meta">Units: ${escapeHtml(d.meta.units || 'mg/dL')} · Target ${escapeHtml(String(d.meta.target_low_mgdl ?? ''))}–${escapeHtml(String(d.meta.target_high_mgdl ?? ''))} mg/dL · Aggregation: ${escapeHtml(d.meta.aggregation || '')}</p>` : ''}
+                </section>
+              </div>
+              `;
+        }
+
         const sendButton = document.getElementById('sendToAiButton');
         if (sendButton) {
 
@@ -249,300 +534,6 @@ function init(ctx) {
                     type: 'GET',
                     headers: headers,
                     success: function (prompts) {
-
-                        /**
-                         * Unified CGM Report Renderer
-                         * - Auto-detects Daily vs Multi-Day schema
-                         * - Plain JS, framework-agnostic
-                         * - Renders accessible HTML with headings, lists, and tables
-                         */
-
-                        function renderCgmReport(data, mount) {
-                            const el = typeof mount === 'string' ? document.querySelector(mount) : mount;
-                            if (!el) throw new Error('Mount element not found');
-
-                            const isMultiDay = !!data.period; // final schema has "period"
-                            el.innerHTML = isMultiDay ? renderMultiDay(data) : renderDaily(data);
-                        }
-
-                        /* ---------- Utilities ---------- */
-
-                        const fmt = (val, unit = '', decimals = 1) =>
-                            val === null || val === undefined || Number.isNaN(val)
-                                ? '-'
-                                : `${Number(val).toFixed(decimals)}${unit}`;
-
-                        const list = (items = []) =>
-                            `<ul>${(items || []).map((x) => `<li>${escapeHtml(x)}</li>`).join('')}</ul>`;
-
-                        function escapeHtml(s) {
-                            return String(s)
-                                .replaceAll('&', '&amp;')
-                                .replaceAll('<', '&lt;')
-                                .replaceAll('>', '&gt;')
-                                .replaceAll('"', '&quot;')
-                                .replaceAll("'", '&#039;');
-                        }
-
-                        function table({head, rows}) {
-                            return `
-                              <table class="cgm-table" role="table">
-                                <thead><tr>${head.map((h) => `<th scope="col">${escapeHtml(h)}</th>`).join('')}</tr></thead>
-                                <tbody>
-                                  ${rows.map((r) => `<tr>${r.map((c) => `<td>${c}</td>`).join('')}</tr>`).join('')}
-                                </tbody>
-                              </table>`;
-                        }
-
-                        /* ---------- Daily (Interim) ---------- */
-
-                        function renderDaily(d) {
-                            const stats = d.statistics || {};
-                            const blocks = d.dailyPatterns || {};
-
-                            const statsTable = table({
-                                head: ['Metric', 'Value'],
-                                rows: [
-                                    ['Average Glucose', fmt(stats.average_glucose_mgdl, ' mg/dL')],
-                                    ['Median Glucose', fmt(stats.median_glucose_mgdl, ' mg/dL')],
-                                    ['Standard Deviation', fmt(stats.standard_deviation_mgdl, ' mg/dL')],
-                                    ['CV', fmt(stats.cv_percent, ' %')],
-                                    ['MAGE', fmt(stats.mage_mgdl, ' mg/dL')],
-                                    ['Time in Range', fmt(stats.time_in_range_percent, ' %')],
-                                    ['Time Below Range', fmt(stats.time_below_range_percent, ' %')],
-                                    ['Time Above Range', fmt(stats.time_above_range_percent, ' %')],
-                                    ['Hypo Episodes', escapeHtml(stats.number_of_hypo_episodes ?? '-')],
-                                    ['Hyper Episodes', escapeHtml(stats.number_of_hyper_episodes ?? '-')],
-                                    ['Longest Hypo', stats.longest_hypo_min != null ? `${stats.longest_hypo_min} min` : '-'],
-                                    ['Longest Hyper', stats.longest_hyper_min != null ? `${stats.longest_hyper_min} min` : '-']
-                                ]
-                            });
-
-                            const patternRows = ['00-06', '06-12', '12-18', '18-24'].map((b) => {
-                                const v = blocks[b] || {};
-                                return [
-                                    b,
-                                    fmt(v.avg, ' mg/dL'),
-                                    fmt(v.sd, ' mg/dL'),
-                                    fmt(v.below_pct, ' %'),
-                                    fmt(v.in_range_pct, ' %'),
-                                    fmt(v.above_pct, ' %')
-                                ];
-                            });
-
-                            const patternsTable = table({
-                                head: ['Time Block', 'Avg', 'SD', 'Below %', 'In Range %', 'Above %'],
-                                rows: patternRows
-                            });
-
-                            const anomaliesList = list(
-                                (d.anomalies || []).map((a) => {
-                                    const base = `${a.type} ${a.start_local}–${a.end_local} (${a.duration_min ?? '-'} min)`;
-                                    if (a.type === 'hypoglycemia' && a.nadir_mgdl != null) return `${base}; nadir ${a.nadir_mgdl} mg/dL`;
-                                    if (a.type === 'hyperglycemia' && a.peak_mgdl != null) return `${base}; peak ${a.peak_mgdl} mg/dL`;
-                                    return base;
-                                })
-                            );
-
-                            return `
-                              <style>
-                                .cgm-wrap{font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:960px;margin:auto;line-height:1.45}
-                                .cgm-wrap h1{font-size:1.6rem;margin:0 0 .5rem}
-                                .cgm-wrap h2{font-size:1.2rem;margin:1.2rem 0 .6rem}
-                                .cgm-wrap h3{font-size:1rem;margin:1rem 0 .5rem;color:#333}
-                                .cgm-table{width:100%;border-collapse:collapse;font-size:.95rem}
-                                .cgm-table th,.cgm-table td{border:1px solid #e5e7eb;padding:.5rem .6rem;text-align:left;vertical-align:top}
-                                .cgm-table thead th{background:#f8fafc;font-weight:600}
-                                ul{padding-left:1.2rem;margin:.2rem 0}
-                                .cgm-meta{color:#555;font-size:.9rem}
-                                .cgm-grid{display:grid;grid-template-columns:1fr;gap:1rem}
-                                @media (min-width:900px){.cgm-grid{grid-template-columns:1fr 1fr}}
-                              </style>
-                            
-                              <div class="cgm-wrap">
-                                <h1>Daily CGM Report — ${escapeHtml(d.date || '')}</h1>
-                                <div class="cgm-grid">
-                                  <section>
-                                    <h2>Summary</h2>
-                                    ${list(d.summary || [])}
-                                    <h2>Statistics</h2>
-                                    ${statsTable}
-                                  </section>
-                                  <section>
-                                    <h2>Daily Patterns</h2>
-                                    ${patternsTable}
-                                    <h2>Anomalies</h2>
-                                    ${anomaliesList}
-                                  </section>
-                                </div>
-                            
-                                <section>
-                                  <h2>Recommendations</h2>
-                                  ${list(d.recommendations || [])}
-                                </section>
-                            
-                                <section>
-                                  <h2>Data Quality Notes</h2>
-                                  ${list(d.data_quality_notes || d.notes || [])}
-                                  ${d.meta ? `<p class="cgm-meta">Units: ${escapeHtml(d.meta.units || 'mg/dL')} · Target ${escapeHtml(String(d.meta.target_low_mgdl ?? ''))}–${escapeHtml(String(d.meta.target_high_mgdl ?? ''))} mg/dL</p>` : ''}
-                                </section>
-                              </div>
-                              `;
-                        }
-
-                        /* ---------- Multi-Day (Final) ---------- */
-
-                        function renderMultiDay(d) {
-                            const stats = d.overall_statistics || {};
-                            const blocks = d.diurnal_patterns || {};
-                            const episodes = d.episodes || {};
-
-                            const statsTable = table({
-                                head: ['Metric', 'Value'],
-                                rows: [
-                                    ['Average Glucose', fmt(stats.average_glucose_mgdl, ' mg/dL')],
-                                    ['Median Glucose', fmt(stats.median_glucose_mgdl, ' mg/dL')],
-                                    ['Standard Deviation', fmt(stats.standard_deviation_mgdl, ' mg/dL')],
-                                    ['CV', fmt(stats.cv_percent, ' %')],
-                                    ['MAGE Overall', fmt(stats.mage_overall_mgdl, ' mg/dL')],
-                                    ['Time in Range', fmt(stats.time_in_range_percent, ' %')],
-                                    ['Time Below Range', fmt(stats.time_below_range_percent, ' %')],
-                                    ['Time Above Range', fmt(stats.time_above_range_percent, ' %')]
-                                ]
-                            });
-
-                            const patternsTable = table({
-                                head: ['Time Block', 'Avg', 'SD', 'Below %', 'In Range %', 'Above %'],
-                                rows: ['00-06', '06-12', '12-18', '18-24'].map((b) => {
-                                    const v = blocks[b] || {};
-                                    return [
-                                        b,
-                                        fmt(v.avg, ' mg/dL'),
-                                        fmt(v.sd, ' mg/dL'),
-                                        fmt(v.below_pct, ' %'),
-                                        fmt(v.in_range_pct, ' %'),
-                                        fmt(v.above_pct, ' %')
-                                    ];
-                                })
-                            });
-
-                            const epiTable = table({
-                                head: ['Type', 'Count', 'Total Minutes', 'Longest (min)', '00–06', '06–12', '12–18', '18–24'],
-                                rows: ['hypoglycemia', 'hyperglycemia'].map((t) => {
-                                    const e = episodes[t] || {};
-                                    const by = (e.by_block || {});
-                                    return [
-                                        t,
-                                        escapeHtml(e.count ?? '-'),
-                                        escapeHtml(e.total_minutes ?? '-'),
-                                        escapeHtml(e.longest_min ?? '-'),
-                                        escapeHtml(by['00-06'] ?? '-'),
-                                        escapeHtml(by['06-12'] ?? '-'),
-                                        escapeHtml(by['12-18'] ?? '-'),
-                                        escapeHtml(by['18-24'] ?? '-')
-                                    ];
-                                })
-                            });
-
-                            const perDayTable = table({
-                                head: ['Date', 'Avg', 'CV %', 'TIR %', 'TBR %', 'TAR %', 'Hypo Ep.', 'Hyper Ep.', 'Notes'],
-                                rows: (d.per_day || []).map((x) => [
-                                    escapeHtml(x.date || ''),
-                                    fmt(x.average_glucose_mgdl, ' mg/dL'),
-                                    fmt(x.cv_percent, ' %'),
-                                    fmt(x.tir_percent, ' %'),
-                                    fmt(x.tbr_percent, ' %'),
-                                    fmt(x.tar_percent, ' %'),
-                                    escapeHtml(x.hypo_episodes ?? '-'),
-                                    escapeHtml(x.hyper_episodes ?? '-'),
-                                    escapeHtml((x.notes || []).join('; '))
-                                ])
-                            });
-
-                            const rec = d.recommendations || {};
-                            const recHtml = `
-                                <div class="cgm-grid">
-                                  <section>
-                                    <h3>Therapy Settings</h3>${list(rec.therapy_settings || [])}
-                                  </section>
-                                  <section>
-                                    <h3>Behavioral Timing</h3>${list(rec.behavioral_timing || [])}
-                                  </section>
-                                  <section>
-                                    <h3>Monitoring</h3>${list(rec.monitoring || [])}
-                                  </section>
-                                </div>
-                              `;
-
-                            return `
-                              <style>
-                                .cgm-wrap{font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:1024px;margin:auto;line-height:1.45}
-                                .cgm-wrap h1{font-size:1.6rem;margin:0 0 .5rem}
-                                .cgm-wrap h2{font-size:1.2rem;margin:1.2rem 0 .6rem}
-                                .cgm-wrap h3{font-size:1rem;margin:1rem 0 .5rem;color:#333}
-                                .cgm-table{width:100%;border-collapse:collapse;font-size:.95rem}
-                                .cgm-table th,.cgm-table td{border:1px solid #e5e7eb;padding:.5rem .6rem;text-align:left;vertical-align:top}
-                                .cgm-table thead th{background:#f8fafc;font-weight:600}
-                                ul{padding-left:1.2rem;margin:.2rem 0}
-                                .cgm-meta{color:#555;font-size:.9rem}
-                                .cgm-grid{display:grid;grid-template-columns:1fr;gap:1rem}
-                                @media (min-width:900px){.cgm-grid{grid-template-columns:repeat(3,1fr)}}
-                              </style>
-                            
-                              <div class="cgm-wrap">
-                                <h1>Multi‑Day CGM Report — ${escapeHtml((d.period?.from || '') + ' – ' + (d.period?.to || ''))}</h1>
-                                <p class="cgm-meta">${escapeHtml(String(d.period?.days ?? ''))} days total</p>
-                            
-                                <section>
-                                  <h2>Summary</h2>
-                                  ${list(d.summary || [])}
-                                </section>
-                            
-                                <div class="cgm-grid">
-                                  <section>
-                                    <h2>Overall Statistics</h2>
-                                    ${statsTable}
-                                  </section>
-                                  <section>
-                                    <h2>Diurnal Patterns</h2>
-                                    ${patternsTable}
-                                  </section>
-                                  <section>
-                                    <h2>Episodes</h2>
-                                    ${epiTable}
-                                  </section>
-                                </div>
-                            
-                                <section>
-                                  <h2>Trends</h2>
-                                  ${list((d.trends || []).map(t => `${t.label}: ${t.evidence}`))}
-                                </section>
-                            
-                                <section>
-                                  <h2>Recommendations</h2>
-                                  ${recHtml}
-                                </section>
-                            
-                                <section>
-                                  <h2>Daily Breakdown</h2>
-                                  ${perDayTable}
-                                </section>
-                            
-                                <section>
-                                  <h2>Data Quality Notes</h2>
-                                  ${list(d.data_quality_notes || [])}
-                                  ${d.meta ? `<p class="cgm-meta">Units: ${escapeHtml(d.meta.units || 'mg/dL')} · Target ${escapeHtml(String(d.meta.target_low_mgdl ?? ''))}–${escapeHtml(String(d.meta.target_high_mgdl ?? ''))} mg/dL · Aggregation: ${escapeHtml(d.meta.aggregation || '')}</p>` : ''}
-                                </section>
-                              </div>
-                              `;
-                        }
-
-                        /* ---------- Example usage ----------
-                           For a daily object: renderCgmReport(dailyJson, '#report');
-                           For a multi-day object: renderCgmReport(finalJson, '#report');
-                        */
-                        // renderCgmReport(yourDataObject, '#report');
-
 
                         const dummyFinalSystemPrompt = "You are an endocrinologist specialized in type 1 diabetes and Nightscout analytics. Your task is to synthesize multiple single-day analyses (already standardized JSON) plus the Nightscout profile.\n" +
                             "\n" +
@@ -836,15 +827,15 @@ function init(ctx) {
                                         return costString;
                                     }
 
-                                    const statsHtml = '<p><strong>AI Usage Statistics</strong><br>' +
-                                   'for ${window.aiResponsesDataObject.date_from} - ${window.aiResponsesDataObject.date_till} (${window.aiResponsesDataObject.interim_calls_amount} days)<br>' +
-                                        'Total API Calls: ${window.aiResponsesDataObject.total_calls} (Interim: ${window.aiResponsesDataObject.interim_calls_amount}, Final: 1)</p>' +
-                                    '<p><strong>Overall Session Usage:</strong></p>' +
-                                    '<ul>' +
-                                        '<li>Prompt Tokens: ${window.aiResponsesDataObject.prompt_tokens_used} ${calculateAndFormatCost(window.aiResponsesDataObject.prompt_tokens_used, costInput, exchangeRateInfo)}</li>' +
-                                        '<li>Completion Tokens: ${window.aiResponsesDataObject.completion_tokens_used} ${calculateAndFormatCost(window.aiResponsesDataObject.completion_tokens_used, costOutput, exchangeRateInfo)}</li>' +
-                                        '<li>Total Tokens: ${window.aiResponsesDataObject.total_tokens_used} ${calculateAndFormatCost(window.aiResponsesDataObject.prompt_tokens_used, costInput, exchangeRateInfo)}</li>' +
-                                    '</ul>';
+                                    const statsHtml = `<p><strong>AI Usage Statistics</strong><br>
+                                   for ${window.aiResponsesDataObject.date_from} - ${window.aiResponsesDataObject.date_till} (${window.aiResponsesDataObject.interim_calls_amount} days)<br>
+                                        Total API Calls: ${window.aiResponsesDataObject.total_calls} (Interim: ${window.aiResponsesDataObject.interim_calls_amount}, Final: 1, Repairs: ${window.aiRepairCalls || 0})</p>
+                                    <p><strong>Overall Session Usage:</strong></p>
+                                    <ul>
+                                        <li>Prompt Tokens: ${window.aiResponsesDataObject.prompt_tokens_used} ${calculateAndFormatCost(window.aiResponsesDataObject.prompt_tokens_used, costInput, exchangeRateInfo)}</li>
+                                        <li>Completion Tokens: ${window.aiResponsesDataObject.completion_tokens_used} ${calculateAndFormatCost(window.aiResponsesDataObject.completion_tokens_used, costOutput, exchangeRateInfo)}</li>
+                                        <li>Total Tokens: ${window.aiResponsesDataObject.total_tokens_used} ${calculateAndFormatCost(window.aiResponsesDataObject.prompt_tokens_used, costInput, exchangeRateInfo)}</li>
+                                    </ul>`;
 
                                     if (statisticsArea) {
                                         statisticsArea.innerHTML = statsHtml;


### PR DESCRIPTION
This commit addresses three critical issues identified in the AI Evaluation plugin's report tab:

1.  **fix(ai_eval): Resolve `renderCgmReport` ReferenceError**
    - The `renderCgmReport` function and its helper utilities have been moved to a higher scope within the `initializeAiEvalTab` function.
    - This corrects a `ReferenceError` that occurred because the interim (daily) reports were being rendered before the function was defined within an AJAX callback. The function is now accessible to all rendering logic.

2.  **fix(ai_eval): Adjust final report layout**
    - The `cgm-grid` container has been removed from around the "Overall Statistics", "Diurnal Patterns", and "Episodes" sections in the multi-day report.
    - This change ensures these sections stack vertically as intended, rather than being displayed in three columns on wider screens.

3.  **fix(ai_eval): Correct AI statistics box rendering**
    - The `statsHtml` string was being defined with single quotes, which prevented template literals from being evaluated. This has been corrected by using backticks (` `).
    - As part of this fix, the number of repair calls is now also displayed in the statistics summary for better visibility.