### PR TITLE
fix(ai_eval): Refactor report rendering and fix multiple bugs

### DIFF
--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -451,6 +451,7 @@ function init(ctx) {
 
                 button.disabled = true;
                 window.interimResponses = []; // Reset responses
+                window.parsedInterimResponses = []; // Reset parsed responses
                 window.aiRepairCalls = 0; // Reset repair counter
                 window.accumulatedInterimTokens = {
                     prompt_tokens: 0,
@@ -460,7 +461,6 @@ function init(ctx) {
 
                 const interimResponseDebugArea = document.getElementById('aiEvalInterimResponseDebugArea');
                 const responseOutputArea = document.getElementById('aiResponseOutputArea');
-                const displayMode = document.getElementById('aiResponseDisplayMode').value;
 
                 interimResponseDebugArea.textContent = ''; // Clear previous debug content
                 responseOutputArea.innerHTML = ''; // Clear output area at the beginning
@@ -473,30 +473,24 @@ function init(ctx) {
                     const statusMsg = `Processing day ${i + 1} of ${totalPayloads}...`;
                     console.log(`AI Eval: ${statusMsg}`);
                     button.textContent = `Sending (${i + 1}/${totalPayloads})...`;
-
-                    if (displayMode === 'Show all results') {
-                        responseOutputArea.innerHTML += `<p>${statusMsg}</p>`;
-                    } else {
-                        responseOutputArea.innerHTML = `<p>${statusMsg}</p>`;
-                    }
+                    responseOutputArea.innerHTML = `<p>${statusMsg}</p>`;
 
 
                     try {
                         const data = await callAiWithRetry(payload);
                         window.interimResponses.push(data);
 
-                        if (displayMode === 'Show all results') {
-                            try {
-                                const cleanedContent = data.html_content.trim().replace(/^```json\s*/, '').replace(/```$/, '').trim();
-                                const parsedJson = JSON.parse(cleanedContent);
-                                const tempDiv = document.createElement('div');
-                                renderCgmReport(parsedJson, tempDiv);
-                                responseOutputArea.innerHTML += tempDiv.innerHTML;
-                            } catch (renderError) {
-                                console.error(`AI Eval: Error rendering interim response for day ${i + 1}:`, renderError);
-                                responseOutputArea.innerHTML += `<p style="color: orange;">Could not render interim response for day ${i + 1}. See console for details.</p>`;
-                            }
+                        // Always parse and store the interim response for later rendering
+                        try {
+                            const cleanedContent = data.html_content.trim().replace(/^```json\s*/, '').replace(/```$/, '').trim();
+                            const parsedJson = JSON.parse(cleanedContent);
+                            window.parsedInterimResponses.push(parsedJson);
+                        } catch (parseError) {
+                            console.error(`AI Eval: Error parsing interim response for day ${i + 1}:`, parseError);
+                            // Optionally store an error object instead
+                            window.parsedInterimResponses.push({ error: `Failed to parse response for day ${i + 1}`, content: data.html_content });
                         }
+
 
                         if (passedInClient.settings.ai_llm_debug === true) {
                             const currentDebugText = interimResponseDebugArea.textContent;
@@ -789,11 +783,27 @@ function init(ctx) {
                                     window.aiResponsesDataObject.total_calls = (window.aiResponsesDataObject.interim_calls_amount || 0) + 1 + (window.aiRepairCalls || 0);
                                     window.aiResponsesDataObject.final_call = 1;
 
-                                    // Display results
+                                    // RENDER ALL RESULTS AT THE END
                                     const displayMode = document.getElementById('aiResponseDisplayMode').value;
-                                    if (displayMode === 'Show final result only') {
-                                        responseOutputArea.innerHTML = ''; // Clear interim results before rendering final
+                                    responseOutputArea.innerHTML = ''; // Clear status messages
+
+                                    // Render interim reports if requested
+                                    if (displayMode === 'Show all results' && window.parsedInterimResponses) {
+                                        for (const interimReport of window.parsedInterimResponses) {
+                                            if (interimReport.error) {
+                                                responseOutputArea.innerHTML += `<p style="color: orange;">Could not render an interim response. See console for details.</p>`;
+                                                if (passedInClient.settings.ai_llm_debug === true) {
+                                                    responseOutputArea.innerHTML += `<pre>${escapeHtml(interimReport.content)}</pre>`;
+                                                }
+                                            } else {
+                                                const tempDiv = document.createElement('div');
+                                                renderCgmReport(interimReport, tempDiv);
+                                                responseOutputArea.innerHTML += tempDiv.innerHTML;
+                                            }
+                                        }
                                     }
+
+                                    // Render the final report
                                     try {
                                         const finalContentCleaned = finalData.html_content.trim().replace(/^```json\s*/, '').replace(/```$/, '').trim();
                                         const finalContentParsed = JSON.parse(finalContentCleaned);
@@ -803,9 +813,8 @@ function init(ctx) {
                                     } catch (renderError) {
                                         console.error('AI Eval: Error rendering final response:', renderError);
                                         responseOutputArea.innerHTML += `<p style="color: red;">Error rendering final report. See console for details.</p>`;
-                                        // Still show raw if rendering fails
                                         if (passedInClient.settings.ai_llm_debug === true) {
-                                          responseOutputArea.innerHTML += `<pre>${finalData.html_content}</pre>`;
+                                          responseOutputArea.innerHTML += `<pre>${escapeHtml(finalData.html_content)}</pre>`;
                                         }
                                     }
 


### PR DESCRIPTION
This commit addresses several UI and logic bugs in the AI Evaluation report tab based on your feedback.

- **Rendering Logic:** The entire rendering process has been refactored. Instead of rendering interim reports as they arrive (which caused them to be overwritten by status messages), the plugin now collects all parsed interim JSON responses. Once the final report is also received, it renders all collected reports to the UI at once, providing a stable and complete view.

- **Scoping Error:** A `ReferenceError` for `renderCgmReport` was fixed by moving the function and its helpers to a higher scope, making it accessible to all parts of the client-side code.

- **Layout Fix:** The three main statistics tables ("Overall Statistics", "Diurnal Patterns", "Episodes") in the final report are now stacked vertically as intended, by removing the `cgm-grid` container that was forcing them into columns.

- **Statistics Box:** A bug causing the statistics box to display raw template literals (e.g., `${...}`) has been fixed by converting the string definition to use backticks. The number of repair calls has also been added to this output for better visibility.