### PR TITLE
refactor(ai_eval): Unify report styles and improve rendering logic

### DIFF
--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -101,6 +101,25 @@ function init(ctx) {
             el.innerHTML = isMultiDay ? renderMultiDay(data) : renderDaily(data);
         }
 
+        const unifiedCss = `
+              <style>
+                .cgm-wrap{font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:1024px;margin:auto;line-height:1.45}
+                .cgm-wrap h1{font-size:1.6rem;margin:0 0 .5rem}
+                .cgm-wrap h2{font-size:1.2rem;margin:1.2rem 0 .6rem}
+                .cgm-wrap h3{font-size:1rem;margin:1rem 0 .5rem;color:#333}
+                .cgm-table{width:100%;border-collapse:collapse;font-size:.95rem}
+                .cgm-table th,.cgm-table td{border:1px solid #e5e7eb;padding:.5rem .6rem;text-align:left;vertical-align:top}
+                .cgm-table thead th{background:#f8fafc;font-weight:600}
+                ul{padding-left:1.2rem;margin:.2rem 0}
+                .cgm-meta{color:#555;font-size:.9rem}
+                .cgm-grid-2col, .cgm-grid-3col {display:grid;grid-template-columns:1fr;gap:1rem}
+                @media (min-width:900px){
+                  .cgm-grid-2col {grid-template-columns:repeat(2, 1fr);}
+                  .cgm-grid-3col {grid-template-columns:repeat(3, 1fr);}
+                }
+              </style>
+            `;
+
         /* ---------- Utilities ---------- */
 
         const fmt = (val, unit = '', decimals = 1) =>
@@ -181,23 +200,9 @@ function init(ctx) {
             );
 
             return `
-              <style>
-                .cgm-wrap{font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:960px;margin:auto;line-height:1.45}
-                .cgm-wrap h1{font-size:1.6rem;margin:0 0 .5rem}
-                .cgm-wrap h2{font-size:1.2rem;margin:1.2rem 0 .6rem}
-                .cgm-wrap h3{font-size:1rem;margin:1rem 0 .5rem;color:#333}
-                .cgm-table{width:100%;border-collapse:collapse;font-size:.95rem}
-                .cgm-table th,.cgm-table td{border:1px solid #e5e7eb;padding:.5rem .6rem;text-align:left;vertical-align:top}
-                .cgm-table thead th{background:#f8fafc;font-weight:600}
-                ul{padding-left:1.2rem;margin:.2rem 0}
-                .cgm-meta{color:#555;font-size:.9rem}
-                .cgm-grid{display:grid;grid-template-columns:1fr;gap:1rem}
-                @media (min-width:900px){.cgm-grid{grid-template-columns:1fr 1fr}}
-              </style>
-
               <div class="cgm-wrap">
                 <h1>Daily CGM Report — ${escapeHtml(d.date || '')}</h1>
-                <div class="cgm-grid">
+                <div class="cgm-grid-2col">
                   <section>
                     <h2>Summary</h2>
                     ${list(d.summary || [])}
@@ -297,7 +302,7 @@ function init(ctx) {
 
             const rec = d.recommendations || {};
             const recHtml = `
-                <div class="cgm-grid">
+                <div class="cgm-grid-3col">
                   <section>
                     <h3>Therapy Settings</h3>${list(rec.therapy_settings || [])}
                   </section>
@@ -311,20 +316,6 @@ function init(ctx) {
               `;
 
             return `
-              <style>
-                .cgm-wrap{font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:1024px;margin:auto;line-height:1.45}
-                .cgm-wrap h1{font-size:1.6rem;margin:0 0 .5rem}
-                .cgm-wrap h2{font-size:1.2rem;margin:1.2rem 0 .6rem}
-                .cgm-wrap h3{font-size:1rem;margin:1rem 0 .5rem;color:#333}
-                .cgm-table{width:100%;border-collapse:collapse;font-size:.95rem}
-                .cgm-table th,.cgm-table td{border:1px solid #e5e7eb;padding:.5rem .6rem;text-align:left;vertical-align:top}
-                .cgm-table thead th{background:#f8fafc;font-weight:600}
-                ul{padding-left:1.2rem;margin:.2rem 0}
-                .cgm-meta{color:#555;font-size:.9rem}
-                .cgm-grid{display:grid;grid-template-columns:1fr;gap:1rem}
-                @media (min-width:900px){.cgm-grid{grid-template-columns:repeat(3,1fr)}}
-              </style>
-
               <div class="cgm-wrap">
                 <h1>Multi‑Day CGM Report — ${escapeHtml((d.period?.from || '') + ' – ' + (d.period?.to || ''))}</h1>
                 <p class="cgm-meta">${escapeHtml(String(d.period?.days ?? ''))} days total</p>
@@ -785,7 +776,7 @@ function init(ctx) {
 
                                     // RENDER ALL RESULTS AT THE END
                                     const displayMode = document.getElementById('aiResponseDisplayMode').value;
-                                    responseOutputArea.innerHTML = ''; // Clear status messages
+                                    responseOutputArea.innerHTML = unifiedCss; // Clear status messages and add styles
 
                                     // Render interim reports if requested
                                     if (displayMode === 'Show all results' && window.parsedInterimResponses) {


### PR DESCRIPTION
This commit refactors the CSS styling and rendering logic within the AI Evaluation plugin for better code quality and a more stable user experience.

- The CSS `<style>` blocks that were previously duplicated inside the `renderDaily` and `renderMultiDay` functions have been removed.

- A single, unified stylesheet is now defined in one place. It uses more specific classes (`.cgm-grid-2col`, `.cgm-grid-3col`) to preserve the intended layouts for both report types.

- This unified stylesheet is injected into the DOM before any reports are rendered, resulting in cleaner code and preventing style duplication.