### PR TITLE
fix(ai-eval): Correct button state and report order

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -28,6 +28,8 @@ This document serves as both a user manual and technical documentation for the p
 
 *   **Monthly Spending Limit Check:** The check for the `AI_LLM_MONTHLY_USD_LIMIT` was previously using an inefficient method of calculating the current month's spending. This has been fixed to use the pre-calculated monthly summary, which is faster and more reliable. This ensures that the "Send to AI" button is correctly disabled and a warning is shown when the monthly spending limit is reached.
 *   **Stale Cost Estimate:** Fixed a bug where the "Estimated costs" display would not clear when loading a new dataset. This could lead to a misleading, stale cost being shown if the new analysis did not complete. The estimate is now cleared immediately when new data is loaded.
+*   **Button State During Final Call:** Fixed an issue where the "Send to AI" button would become active between the interim and final analysis calls. The button now displays "Final call..." and remains disabled until the entire process is complete, preventing accidental clicks.
+*   **Report Display Order:** The final summary report is now displayed at the top, above the individual daily (interim) reports, for a more logical and user-friendly layout.
 
 ## User Guide
 

--- a/jules-scratch/verification/verify_report_changes.py
+++ b/jules-scratch/verification/verify_report_changes.py
@@ -1,0 +1,38 @@
+import re
+from playwright.sync_api import Page, expect
+
+def test_ai_eval_fixes(page: Page):
+    """
+    This test verifies that the "Send to AI" button is disabled during the final call
+    and that the final report is rendered before the interim reports.
+    """
+    # 1. Arrange: Go to the Nightscout homepage and navigate to the reports page.
+    # The server is running on port 1337 by default.
+    page.goto("http://localhost:1337")
+
+    # Click the "Reports" link.
+    page.get_by_role("link", name="Reports").click()
+
+    # Wait for the reports page to load.
+    expect(page).to_have_title(re.compile("Reports"))
+
+    # 2. Act: Open the AI Evaluation tab.
+    page.get_by_role("link", name="AI Evaluation").click()
+
+    # Click the "Send to AI" button.
+    send_button = page.locator("#sendToAiButton")
+    send_button.click()
+
+    # 3. Assert: Check the button state and report order.
+    # Wait for the button to be disabled and show "Final call...".
+    expect(send_button).to_be_disabled()
+    expect(send_button).to_have_text("Final call...")
+
+    # Wait for the final report to be rendered.
+    expect(page.locator("h1:has-text('Multi‑Day CGM Report')")).to_be_visible()
+
+    # Wait for the interim reports to be rendered after the final report.
+    expect(page.locator("h1:has-text('Daily CGM Report')")).to_be_visible()
+
+    # 4. Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="jules-scratch/verification/verification.png")

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -503,8 +503,8 @@ function init(ctx) {
 
                 console.log('AI Eval: All interim payloads processed.');
                 responseOutputArea.innerHTML = '<p>All daily analyses complete. Ready to build final report.</p>';
-                button.textContent = 'Send to AI';
-                button.disabled = false; // Re-enable for next step
+                button.textContent = 'Final call...';
+                // Keep button disabled, will be re-enabled in sendFinalPayload's finally block.
 
                 // Here, you would trigger the final payload construction and call
                 // For now, we just log the collected responses.
@@ -729,6 +729,7 @@ function init(ctx) {
 
                         // Automatically send the final payload to the AI
                         const sendFinalPayload = async () => {
+                            const button = document.getElementById('sendToAiButton');
                             const responseOutputArea = document.getElementById('aiResponseOutputArea');
                             const responseDebugArea = document.getElementById('aiEvalResponseDebugArea');
                             const statisticsArea = document.getElementById('aiStatistics');
@@ -779,38 +780,42 @@ function init(ctx) {
 
                                     // RENDER ALL RESULTS AT THE END
                                     const displayMode = document.getElementById('aiResponseDisplayMode').value;
-                                    responseOutputArea.innerHTML = unifiedCss; // Clear status messages and add styles
+                                    let finalReportHtml = '';
+                                    let interimReportsHtml = '';
 
-                                    // Render interim reports if requested
-                                    if (displayMode === 'Show all results' && window.parsedInterimResponses) {
-                                        for (const interimReport of window.parsedInterimResponses) {
-                                            if (interimReport.error) {
-                                                responseOutputArea.innerHTML += `<p style="color: orange;">Could not render an interim response. See console for details.</p>`;
-                                                if (passedInClient.settings.ai_llm_debug === true) {
-                                                    responseOutputArea.innerHTML += `<pre>${escapeHtml(interimReport.content)}</pre>`;
-                                                }
-                                            } else {
-                                                const tempDiv = document.createElement('div');
-                                                renderCgmReport(interimReport, tempDiv);
-                                                responseOutputArea.innerHTML += tempDiv.innerHTML;
-                                            }
-                                        }
-                                    }
-
-                                    // Render the final report
+                                    // 1. Prepare the final report's HTML
                                     try {
                                         const finalContentCleaned = finalData.html_content.trim().replace(/^```json\s*/, '').replace(/```$/, '').trim();
                                         const finalContentParsed = JSON.parse(finalContentCleaned);
                                         const tempDiv = document.createElement('div');
                                         renderCgmReport(finalContentParsed, tempDiv);
-                                        responseOutputArea.innerHTML += tempDiv.innerHTML;
+                                        finalReportHtml = tempDiv.innerHTML;
                                     } catch (renderError) {
                                         console.error('AI Eval: Error rendering final response:', renderError);
-                                        responseOutputArea.innerHTML += `<p style="color: red;">Error rendering final report. See console for details.</p>`;
+                                        finalReportHtml = `<p style="color: red;">Error rendering final report. See console for details.</p>`;
                                         if (passedInClient.settings.ai_llm_debug === true) {
-                                          responseOutputArea.innerHTML += `<pre>${escapeHtml(finalData.html_content)}</pre>`;
+                                            finalReportHtml += `<pre>${escapeHtml(finalData.html_content)}</pre>`;
                                         }
                                     }
+
+                                    // 2. Prepare interim reports' HTML if requested
+                                    if (displayMode === 'Show all results' && window.parsedInterimResponses) {
+                                        for (const interimReport of window.parsedInterimResponses) {
+                                            if (interimReport.error) {
+                                                interimReportsHtml += `<p style="color: orange;">Could not render an interim response. See console for details.</p>`;
+                                                if (passedInClient.settings.ai_llm_debug === true) {
+                                                    interimReportsHtml += `<pre>${escapeHtml(interimReport.content)}</pre>`;
+                                                }
+                                            } else {
+                                                const tempDiv = document.createElement('div');
+                                                renderCgmReport(interimReport, tempDiv);
+                                                interimReportsHtml += tempDiv.innerHTML;
+                                            }
+                                        }
+                                    }
+
+                                    // 3. Combine and render
+                                    responseOutputArea.innerHTML = unifiedCss + finalReportHtml + interimReportsHtml;
 
 
                                     // --- New Statistics Formatting ---
@@ -888,6 +893,13 @@ function init(ctx) {
                                 responseOutputArea.innerHTML = `<p style="color: red;">Error during final analysis. Please check the console and debug areas for details.</p>`;
                                 if (responseDebugArea) {
                                     responseDebugArea.textContent = `--- FINAL CALL ERROR ---\n${error.message}`;
+                                }
+                            } finally {
+                                // This block ensures the button is always re-enabled and reset,
+                                // whether the try block succeeds or fails.
+                                if (button) {
+                                    button.textContent = 'Send to AI';
+                                    button.disabled = false;
                                 }
                             }
                         };

--- a/npm_output.log
+++ b/npm_output.log
@@ -1,0 +1,3 @@
+
+> nightscout@15.0.3 dev
+> env-cmd -f ./my.env nodemon --inspect lib/server/server.js 0.0.0.0


### PR DESCRIPTION
- Reordered the report rendering to show the final summary before the interim reports.
- Ensured the "Send to AI" button displays "Final call..." and remains disabled during the final analysis step.
- Updated `ai_evaluation.md` to document the fixes.