### PR TITLE
feat(ai-eval): Add cancel button for analysis runs

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -18,6 +18,7 @@ This document serves as both a user manual and technical documentation for the p
 *   **Debugging Mode:** An option to display the exact prompts and model sent to the LLM, shown above the LLM's response in the AI Evaluation tab.
 *   **Secure API Key Handling:** The LLM API key is stored as a server-side environment variable and is not exposed to the client.
 *   **Token Usage Tracking:** Automatically tracks the number of tokens consumed and API calls made to the LLM, viewable in Admin Tools.
+*   **Cancellable Analysis:** A "Cancel" button appears during an active analysis, allowing users to stop the process at any time.
 
 ## Enhancements
 
@@ -158,6 +159,7 @@ A new section in Admin Tools allows you to monitor LLM usage in detail:
         *   **Show final result only:** This will only display the final summary report after all daily analyses are complete.
         *   The default value for this dropdown can be set using the `AI_LLM_DEFAULT_DISPLAY` environment variable.
     *   Click the **"Send to AI"** button to begin the analysis.
+    *   A **"Cancel"** button will appear next to the "Send to AI" button while the analysis is running. Clicking this button will immediately stop the process.
     *   The system will show the progress as it processes each day.
     *   The AI's JSON responses will be rendered into user-friendly HTML tables and lists for easy reading.
     *   **Cost Information:** Below the "Send to AI" button, two lines of cost information will appear:

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -465,6 +465,13 @@ function init(ctx) {
                     console.log('AI Eval: Send to AI button clicked.');
                 }
                 const button = this;
+                const cancelButton = document.getElementById('cancelAiButton');
+                cancelButton.style.display = 'inline-block';
+
+                window.aiEvalCancellationRequested = false;
+                cancelButton.addEventListener('click', function() {
+                    window.aiEvalCancellationRequested = true;
+                });
 
                 if (typeof window === 'undefined' || !window.interimPayloads || window.interimPayloads.length === 0) {
                     console.error('AI Eval: No interim payloads available to send.');
@@ -492,6 +499,15 @@ function init(ctx) {
                 responseOutputArea.innerHTML = `<p>Starting analysis for ${totalPayloads} days...</p>`;
 
                 for (let i = 0; i < totalPayloads; i++) {
+                    if (window.aiEvalCancellationRequested) {
+                        console.log('AI Eval: Cancellation requested by user.');
+                        responseOutputArea.innerHTML = '<p>Analysis cancelled.</p>';
+                        button.textContent = 'Send to AI';
+                        button.disabled = false;
+                        cancelButton.style.display = 'none';
+                        return;
+                    }
+
                     const payload = window.interimPayloads[i];
                     const statusMsg = `Processing day ${i + 1} of ${totalPayloads}...`;
                     console.log(`AI Eval: ${statusMsg}`);
@@ -526,6 +542,7 @@ function init(ctx) {
                         interimResponseDebugArea.textContent += `\n\n--- ERROR for Day ${i + 1} ---\n${error.message}`;
                         button.textContent = 'Send to AI';
                         button.disabled = false;
+                        cancelButton.style.display = 'none';
                         return; // Stop processing on error
                     }
                 }
@@ -756,6 +773,14 @@ function init(ctx) {
                         $('#ai-user-prompt-status').text('Set').removeClass('ai-setting-value-loading').addClass('ai-setting-value-set');
 
 
+                        if (window.aiEvalCancellationRequested) {
+                            console.log('AI Eval: Analysis cancelled before final payload.');
+                            responseOutputArea.innerHTML = '<p>Analysis cancelled.</p>';
+                            button.textContent = 'Send to AI';
+                            button.disabled = false;
+                            cancelButton.style.display = 'none';
+                            return;
+                        }
                         // Automatically send the final payload to the AI
                         const sendFinalPayload = async () => {
                             const button = document.getElementById('sendToAiButton');
@@ -957,6 +982,10 @@ function init(ctx) {
                                 if (button) {
                                     button.textContent = 'Send to AI';
                                     button.disabled = false;
+                                }
+                                const cancelButton = document.getElementById('cancelAiButton');
+                                if (cancelButton) {
+                                    cancelButton.style.display = 'none';
                                 }
                             }
                         };
@@ -1927,6 +1956,7 @@ function init(ctx) {
             </div>
         
             <button id="sendToAiButton" style="margin-top: 10px; padding: 8px 15px;">Send to AI</button>
+            <button id="cancelAiButton" style="margin-top: 10px; padding: 8px 15px; display: none;">Cancel</button>
             <div id="aiEstimatedCost" style="margin-top: 10px;"></div>
             
           <div id="aiResponseOutputArea" style="margin-top: 20px;">


### PR DESCRIPTION
This commit adds a "Cancel" button to the AI Evaluation report, allowing users to stop an in-progress analysis.

The button is only visible during the analysis and, when clicked, sets a flag that gracefully terminates the processing loop and prevents the final API call. The UI is then reset to its idle state.

The user guide in `ai_evaluation.md` has been updated to reflect this new functionality.