### PR TITLE
fix(admin): Render HTML in AI prompt labels

### DIFF
--- a/lib/admin_plugins/ai_settings.js
+++ b/lib/admin_plugins/ai_settings.js
@@ -51,7 +51,7 @@ function init(ctx) {
 
           $formContainer.append(
               $('<div>').css('margin-bottom', '15px').append(
-                  $('<label>').attr('for', systemInterimPromptId).css({display: 'block', marginBottom: '5px'}).text(client.translate('System Interim Prompt:<br>' +
+                  $('<label>').attr('for', systemInterimPromptId).css({display: 'block', marginBottom: '5px'}).html(client.translate('<h3>System Interim Prompt:</h3>' +
                       'Available tokens (optional): {{PROFILE}}, {{INTERIMRETURNFORMAT}}')),
                   $('<textarea>').attr('id', systemInterimPromptId).attr('rows', 5).css({width: '90%', fontFamily: 'monospace'}).attr('placeholder', client.translate('e.g., You are a helpful assistant specializing in diabetes data analysis.'))
               )
@@ -59,15 +59,15 @@ function init(ctx) {
 
           $formContainer.append(
               $('<div>').css('margin-bottom', '15px').append(
-                  $('<label>').attr('for', userInterimPromptTemplateId).css({display: 'block', marginBottom: '5px'}).text(client.translate('User Interim Prompt:<br>' +
-                      'Available mandatory tokens: {{DATE}}, {{CGMDATA}}, {{PROFILE}}, {{INTERIMRETURNFORMAT}})')),
+                  $('<label>').attr('for', userInterimPromptTemplateId).css({display: 'block', marginBottom: '5px'}).html(client.translate('<h3>User Interim Prompt:</h3>' +
+                      'Available mandatory tokens: {{DATE}}, {{CGMDATA}}, {{PROFILE}}, {{INTERIMRETURNFORMAT}}')),
                   $('<textarea>').attr('id', userInterimPromptTemplateId).attr('rows', 10).css({width: '90%', fontFamily: 'monospace'}).attr('placeholder', client.translate('e.g., Analyze the following CGM data: {{CGMDATA}} with the following profile: {{PROFILE}}. Provide insights on patterns and suggest improvements.'))
               )
           );
 
           $formContainer.append(
               $('<div>').css('margin-bottom', '15px').append(
-                  $('<label>').attr('for', systemPromptId).css({display: 'block', marginBottom: '5px'}).text(client.translate('System Prompt:<br>' +
+                  $('<label>').attr('for', systemPromptId).css({display: 'block', marginBottom: '5px'}).html(client.translate('<h3>System Prompt:</h3>' +
                       'Available tokens (optional): {{PROFILE}}, {{FINALRETURNFORMAT}}')),
                   $('<textarea>').attr('id', systemPromptId).attr('rows', 5).css({width: '90%', fontFamily: 'monospace'}).attr('placeholder', client.translate('e.g., You are a helpful assistant specializing in diabetes data analysis.'))
               )
@@ -75,9 +75,9 @@ function init(ctx) {
 
           $formContainer.append(
               $('<div>').css('margin-bottom', '15px').append(
-                  $('<label>').attr('for', userPromptTemplateId).css({display: 'block', marginBottom: '5px'}).text(client.translate('User Prompt<br>' +
+                  $('<label>').attr('for', userPromptTemplateId).css({display: 'block', marginBottom: '5px'}).html(client.translate('<h3>User Prompt</h3>' +
                       'Available mandatory tokens: {{INTERIMAIDATA}}, {{FINALRETURNFORMAT}}<br>' +
-                      'Available optional tokens: {{TIMEFROM}}, {{TIMETILL}}, {{DAYS}}, {{PROFILE}})')),
+                      'Available optional tokens: {{TIMEFROM}}, {{TIMETILL}}, {{DAYS}}, {{PROFILE}}')),
                   $('<textarea>').attr('id', userPromptTemplateId).attr('rows', 10).css({width: '90%', fontFamily: 'monospace'}).attr('placeholder', client.translate('e.g., Analyze the following summaries of cgm-data: {{INTERIMAIDATA}}. The following insulin profile is in use: {{PROFILE}}. Provide insights on patterns and suggest improvements.'))
               )
           );


### PR DESCRIPTION
The labels for the AI prompt textareas in the admin settings were using the .text() jQuery method, which prevented HTML tags like <br> from being rendered.

This commit switches to using the .html() method and wraps the label titles in <h3> tags to allow for proper formatting and improved visual hierarchy, as requested by the user.