### PR TITLE
fix(ai-eval): Ensure cancel button fully resets analysis state

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -18,7 +18,7 @@ This document serves as both a user manual and technical documentation for the p
 *   **Debugging Mode:** An option to display the exact prompts and model sent to the LLM, shown above the LLM's response in the AI Evaluation tab.
 *   **Secure API Key Handling:** The LLM API key is stored as a server-side environment variable and is not exposed to the client.
 *   **Token Usage Tracking:** Automatically tracks the number of tokens consumed and API calls made to the LLM, viewable in Admin Tools.
-*   **Cancellable Analysis:** A "Cancel" button appears during an active analysis, allowing users to stop the process at any time.
+*   **Cancellable Analysis:** A "Cancel" button appears during an active analysis, allowing users to stop the process at any time. Clicking it fully resets the analysis state, allowing for a clean start.
 
 ## Enhancements
 
@@ -159,7 +159,7 @@ A new section in Admin Tools allows you to monitor LLM usage in detail:
         *   **Show final result only:** This will only display the final summary report after all daily analyses are complete.
         *   The default value for this dropdown can be set using the `AI_LLM_DEFAULT_DISPLAY` environment variable.
     *   Click the **"Send to AI"** button to begin the analysis.
-    *   A **"Cancel"** button will appear next to the "Send to AI" button while the analysis is running. Clicking this button will immediately stop the process.
+    *   A **"Cancel"** button will appear next to the "Send to AI" button while the analysis is running. Clicking this button will immediately stop the process and completely reset the interface, allowing you to start a new analysis from a clean state.
     *   The system will show the progress as it processes each day.
     *   The AI's JSON responses will be rendered into user-friendly HTML tables and lists for easy reading.
     *   **Cost Information:** Below the "Send to AI" button, two lines of cost information will appear:

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -171,6 +171,105 @@ function init(ctx) {
                 .replaceAll("'", '&#039;');
         }
 
+        function resetAiAnalysis() {
+            console.log('AI Eval: Resetting analysis state.');
+
+            // Reset buttons
+            const sendButton = document.getElementById('sendToAiButton');
+            if (sendButton) {
+                sendButton.textContent = 'Send to AI';
+                sendButton.disabled = false;
+            }
+            const cancelButton = document.getElementById('cancelAiButton');
+            if (cancelButton) {
+                cancelButton.style.display = 'none';
+            }
+
+            // Clear output areas
+            const responseOutputArea = document.getElementById('aiResponseOutputArea');
+            if (responseOutputArea) {
+                responseOutputArea.innerHTML = '<p>Ready for new analysis.</p>';
+            }
+            const statisticsArea = document.getElementById('aiStatistics');
+            if (statisticsArea) {
+                statisticsArea.innerHTML = '';
+                statisticsArea.style.display = 'none';
+            }
+
+            // Reset global state variables
+            if (typeof window !== 'undefined') {
+                window.aiEvalCancellationRequested = false;
+                window.interimResponses = [];
+                window.parsedInterimResponses = [];
+                window.accumulatedInterimTokens = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+                window.aiResponsesDataObject = {};
+                if (window.currentAiEvalfinalPayload) {
+                    delete window.currentAiEvalfinalPayload;
+                }
+            }
+        }
+
+        function resetAiAnalysis(isNewReport = false) {
+            console.log('AI Eval: Resetting analysis state.');
+
+            // Reset buttons
+            const sendButton = document.getElementById('sendToAiButton');
+            if (sendButton) {
+                sendButton.textContent = 'Send to AI';
+                sendButton.disabled = false;
+            }
+            const cancelButton = document.getElementById('cancelAiButton');
+            if (cancelButton) {
+                cancelButton.style.display = 'none';
+            }
+
+            // Clear output areas
+            const responseOutputArea = document.getElementById('aiResponseOutputArea');
+            if (responseOutputArea) {
+                responseOutputArea.innerHTML = isNewReport ? 'Awaiting new data...' : '<p>Ready for new analysis.</p>';
+            }
+            const statisticsArea = document.getElementById('aiStatistics');
+            if (statisticsArea) {
+                statisticsArea.innerHTML = '';
+                statisticsArea.style.display = 'none';
+            }
+            const estimatedCostArea = document.getElementById('aiEstimatedCost');
+            if (estimatedCostArea) {
+                estimatedCostArea.innerHTML = '';
+            }
+
+            const debugText = isNewReport ? 'Awaiting report data processing...' : 'Ready for new analysis.';
+            const interimDebugArea = document.getElementById('aiEvalInterimDebugArea');
+            if (interimDebugArea) interimDebugArea.textContent = debugText;
+
+            const interimResponseDebugArea = document.getElementById('aiEvalInterimResponseDebugArea');
+            if (interimResponseDebugArea) interimResponseDebugArea.textContent = isNewReport ? 'Awaiting interim AI call...' : '';
+
+            const debugArea = document.getElementById('aiEvalDebugArea');
+            if (debugArea) debugArea.textContent = debugText;
+
+            const responseDebugArea = document.getElementById('aiEvalResponseDebugArea');
+            if (responseDebugArea) responseDebugArea.textContent = isNewReport ? 'AI Response Debug Area: Waiting for AI call...' : '';
+
+
+            // Reset global state variables
+            if (typeof window !== 'undefined') {
+                window.aiEvalCancellationRequested = false;
+                window.interimPayloads = [];
+                window.interimResponses = [];
+                window.parsedInterimResponses = [];
+                window.aiRepairCalls = 0;
+                window.accumulatedInterimTokens = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+                window.aiResponsesDataObject = {};
+                if (window.currentAiEvalfinalPayload) {
+                    delete window.currentAiEvalfinalPayload;
+                }
+                if (window.exchangeRateInfo) {
+                    delete window.exchangeRateInfo;
+                }
+            }
+        }
+
         function table({head, rows}) {
             return `
               <table class="cgm-table" role="table">
@@ -471,6 +570,8 @@ function init(ctx) {
                 window.aiEvalCancellationRequested = false;
                 cancelButton.addEventListener('click', function() {
                     window.aiEvalCancellationRequested = true;
+                    resetAiAnalysis();
+                    responseOutputArea.innerHTML = '<p>Analysis cancelled by user.</p>';
                 });
 
                 if (typeof window === 'undefined' || !window.interimPayloads || window.interimPayloads.length === 0) {
@@ -2126,45 +2227,8 @@ function init(ctx) {
             console.log('AI Eval: REPORT function called. Data received:', !!datastorage, 'Options Report Name:', options ? options.reportName : 'N/A');
 
             if (typeof window !== 'undefined') {
-                // 1. Reset all AI-related data and UI elements
-                console.log('AI Eval: Resetting AI data and UI from report function.');
-
-                // Reset global variables
-                window.interimPayloads = [];
-                window.interimResponses = [];
-                window.aiResponsesDataObject = {}; // Clear the main data object
-                if (window.currentAiEvalfinalPayload) {
-                    delete window.currentAiEvalfinalPayload;
-                }
-                if (window.exchangeRateInfo) {
-                    delete window.exchangeRateInfo;
-                }
-
-                // Reset UI Elements
-                const responseOutputArea = document.getElementById('aiResponseOutputArea');
-                if (responseOutputArea) responseOutputArea.innerHTML = 'Awaiting new data...';
-
-                const statisticsArea = document.getElementById('aiStatistics');
-                if (statisticsArea) {
-                    statisticsArea.innerHTML = '';
-                    statisticsArea.style.display = 'none';
-                }
-
-                const estimatedCostArea = document.getElementById('aiEstimatedCost');
-                if (estimatedCostArea) estimatedCostArea.innerHTML = '';
-
-                const interimDebugArea = document.getElementById('aiEvalInterimDebugArea');
-                if (interimDebugArea) interimDebugArea.textContent = 'Awaiting report data processing...';
-
-                const interimResponseDebugArea = document.getElementById('aiEvalInterimResponseDebugArea');
-                if (interimResponseDebugArea) interimResponseDebugArea.textContent = 'Awaiting interim AI call...';
-
-                const debugArea = document.getElementById('aiEvalDebugArea');
-                if (debugArea) debugArea.textContent = 'Awaiting report data processing...';
-
-                const responseDebugArea = document.getElementById('aiEvalResponseDebugArea');
-                if (responseDebugArea) responseDebugArea.textContent = 'AI Response Debug Area: Waiting for AI call...';
-
+                // 1. Reset all AI-related data and UI elements for the new report.
+                resetAiAnalysis(true);
 
                 // 2. Store new data for processing
                 window.tempAiEvalReportData = {


### PR DESCRIPTION
Previously, the cancel button would only stop the execution of the analysis loop but did not reset the global state variables or the UI completely. This could lead to inconsistent states if a new analysis was started after a cancellation.

This commit introduces a centralized `resetAiAnalysis` function that handles a full state and UI reset. This function is now called when a new report is generated and when the user clicks the "Cancel" button, ensuring a clean and predictable state for every analysis run.