### PR TITLE
fix(ai-eval): Ensure state is reset on analysis cancellation

### DIFF
--- a/ai_evaluation.md
+++ b/ai_evaluation.md
@@ -32,6 +32,7 @@ This document serves as both a user manual and technical documentation for the p
 *   **Stale Cost Estimate:** Fixed a bug where the "Estimated costs" display would not clear when loading a new dataset. This could lead to a misleading, stale cost being shown if the new analysis did not complete. The estimate is now cleared immediately when new data is loaded.
 *   **Button State During Final Call:** Fixed an issue where the "Send to AI" button would become active between the interim and final analysis calls. The button now displays "Final call..." and remains disabled until the entire process is complete, preventing accidental clicks.
 *   **Report Display Order:** The final summary report is now displayed at the top, above the individual daily (interim) reports, for a more logical and user-friendly layout.
+*   **Analysis State Reset on Cancellation:** Fixed a critical bug where cancelling an analysis would not fully reset the plugin's state. Previously, starting a new analysis after a cancellation would cause it to resume from the old, cancelled state. The cancellation process now performs a complete reset of all data and UI elements, ensuring that users can start a fresh analysis from a clean slate without needing to reload the report.
 
 ## User Guide
 

--- a/lib/report_plugins/ai_eval.js
+++ b/lib/report_plugins/ai_eval.js
@@ -394,6 +394,50 @@ function init(ctx) {
               `;
         }
 
+        function resetAiAnalysis() {
+            if (typeof window.aiEvalClient !== 'undefined' && window.aiEvalClient.settings.ai_llm_debug === true) {
+                console.log('AI Eval: resetAiAnalysis called.');
+            }
+
+            // Reset global state variables
+            window.aiEvalCancellationRequested = false;
+            window.interimResponses = [];
+            window.parsedInterimResponses = [];
+            window.accumulatedInterimTokens = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+            window.aiRepairCalls = 0;
+            if (window.currentAiEvalfinalPayload) delete window.currentAiEvalfinalPayload;
+            if (window.aiResponsesDataObject) window.aiResponsesDataObject = {};
+
+
+            // Reset UI elements
+            const button = document.getElementById('sendToAiButton');
+            if (button) {
+                button.textContent = 'Send to AI';
+                button.disabled = false;
+            }
+
+            const cancelButton = document.getElementById('cancelAiButton');
+            if (cancelButton) {
+                cancelButton.style.display = 'none';
+            }
+
+            const responseOutputArea = document.getElementById('aiResponseOutputArea');
+            if (responseOutputArea) {
+                responseOutputArea.innerHTML = '<p>Analysis was cancelled or reset. Ready to start a new analysis.</p>';
+            }
+
+            const statisticsArea = document.getElementById('aiStatistics');
+            if (statisticsArea) {
+                statisticsArea.innerHTML = '';
+                statisticsArea.style.display = 'none';
+            }
+
+            const interimResponseDebugArea = document.getElementById('aiEvalInterimResponseDebugArea');
+            if (interimResponseDebugArea) {
+                 interimResponseDebugArea.textContent = 'Awaiting interim AI call...';
+            }
+        }
+
         const sendButton = document.getElementById('sendToAiButton');
         if (sendButton) {
 
@@ -471,6 +515,7 @@ function init(ctx) {
                 window.aiEvalCancellationRequested = false;
                 cancelButton.addEventListener('click', function() {
                     window.aiEvalCancellationRequested = true;
+                    resetAiAnalysis(); // Call the centralized reset function
                 });
 
                 if (typeof window === 'undefined' || !window.interimPayloads || window.interimPayloads.length === 0) {
@@ -500,11 +545,9 @@ function init(ctx) {
 
                 for (let i = 0; i < totalPayloads; i++) {
                     if (window.aiEvalCancellationRequested) {
-                        console.log('AI Eval: Cancellation requested by user.');
-                        responseOutputArea.innerHTML = '<p>Analysis cancelled.</p>';
-                        button.textContent = 'Send to AI';
-                        button.disabled = false;
-                        cancelButton.style.display = 'none';
+                        console.log('AI Eval: Cancellation requested by user during interim calls.');
+                        // The reset is already handled by the button's click listener.
+                        // We just need to stop the loop.
                         return;
                     }
 
@@ -775,10 +818,8 @@ function init(ctx) {
 
                         if (window.aiEvalCancellationRequested) {
                             console.log('AI Eval: Analysis cancelled before final payload.');
-                            responseOutputArea.innerHTML = '<p>Analysis cancelled.</p>';
-                            button.textContent = 'Send to AI';
-                            button.disabled = false;
-                            cancelButton.style.display = 'none';
+                            // The reset is already handled by the button's click listener.
+                            // We just need to stop the process.
                             return;
                         }
                         // Automatically send the final payload to the AI


### PR DESCRIPTION
Previously, cancelling an in-progress AI analysis did not fully reset the application's state. This caused subsequent analysis runs to resume from the point of cancellation instead of starting fresh.

This commit introduces a centralized `resetAiAnalysis` function that is responsible for clearing all relevant global variables and resetting UI elements to their initial state.

The "Cancel" button's event listener is updated to call this new function directly, ensuring a complete and clean reset. The now-redundant code in other cancellation checks has been removed to simplify the logic.

This change fixes the inconsistent state bug and allows users to reliably start a new analysis after cancelling a previous one.